### PR TITLE
Release/1.0.7

### DIFF
--- a/MODIS/ModisDownload.R
+++ b/MODIS/ModisDownload.R
@@ -31,7 +31,7 @@ if (requireNamespace('parallel', quietly = TRUE)) { MD_MaxNCores <- 4
 } else { MD_MaxNCores <- 1 }
 # palfaro @ 2017-01-09
 # create a RCurl handle which will be reused between connections to enable http keepalives
-MD_curlHandle <- getCurlHandle()
+MD_curlHandle <- RCurl::getCurlHandle()
 
 modisProducts <- function() {
   .ModisLPxxx <- NULL
@@ -282,7 +282,7 @@ getNativeTemporalResolution <- function(product) {
       # using clusterEvalQ
       clusterEvalQ(cl, expr = { 
         require('RCurl')
-        MD_curlHandle <- getCurlHandle() })
+        MD_curlHandle <- RCurl::getCurlHandle() })
       Modislist <- parLapplyLB(cl=cl, X=dirs, fun=getModisName, productURL=x, h=h, v=v, opt=opt, serverErrorsPattern=serverErrorsPattern, forceReDownload=forceReDownload)
       stopCluster(cl)
     } else {
@@ -438,7 +438,7 @@ getNativeTemporalResolution <- function(product) {
     # using clusterEvalQ
     clusterEvalQ(cl, expr = { 
       require('RCurl')
-      MD_curlHandle <- getCurlHandle() })
+      MD_curlHandle <- RCurl::getCurlHandle() })
     clusterExport(cl=cl, varlist=c(".downloadHTTP"), envir=environment())
     res <- parLapplyLB(cl=cl, X = 1:nrow(plainModisList), fun = getFile, plainModisList=plainModisList, opt=opt, forceReDownload=forceReDownload)
     stopCluster(cl)

--- a/SeriesTemporales/leerSeriesTemporales.r
+++ b/SeriesTemporales/leerSeriesTemporales.r
@@ -124,11 +124,11 @@ leerSeriesXLSX <- function(
   truncated=5, tzFechas='UTC', headerDatos=T, fileEncoding='', 
   na.strings=-1111
 ) {
-  dfEstaciones <- read.xlsx(xlsxFile = pathArchivoDatos, sheet = hojaEstaciones, 
+  dfEstaciones <- openxlsx::read.xlsx(xlsxFile = pathArchivoDatos, sheet = hojaEstaciones, 
                             cols = colsEstaciones, colNames = headerEstaciones)
   dfEstaciones <- setIdsEstaciones(dfEstaciones, colId = colId)
 
-  dfDatos <- read.xlsx(xlsxFile = pathArchivoDatos, sheet = hojaDatos, colNames = headerDatos)
+  dfDatos <- openxlsx::read.xlsx(xlsxFile = pathArchivoDatos, sheet = hojaDatos, colNames = headerDatos)
   dfDatos <- limpiarDatos(dfDatos = dfDatos, dfEstaciones = dfEstaciones, colIdEstaciones = colId, 
                           header = headerDatos, overrideHeader = headerDatos, 
                           formatoFechas = formatoFechas, truncated = truncated, tzFechas = tzFechas)

--- a/descargador/descargadorEx.r
+++ b/descargador/descargadorEx.r
@@ -38,7 +38,7 @@ source(paste0(script.dir.descargadorEx, '../instalarPaquetes/instant_pkgs.r'))
 source(paste0(script.dir.descargadorEx, '../pathUtils/pathUtils.r'))
 instant_pkgs(c('RCurl', 'curl', 'parallel', 'digest', 'data.table', 'stringi', 'stringr', 'lubridate'))
 
-threadHandle <- getCurlHandle()
+threadHandle <- RCurl::getCurlHandle()
 
 getURLEx <- function(url) { return(getURL(url, curl=curlHandle, async=FALSE)) }
 
@@ -49,13 +49,13 @@ extraerEnlaces <- function(urls, patronEnlaces='href="[[:print:]]"', concatenarU
     cl <- makeCluster(getOption("cl.cores", maxNConexiones))
     clusterEvalQ(cl, expr = {
       require('RCurl')
-      curlHandle <- getCurlHandle()
+      curlHandle <- RCurl::getCurlHandle()
     })
     clusterExport(cl = cl, varlist = c('getURLEx'))
     textoshtmls <- parSapplyLB(cl=cl, X=urls, FUN = getURLEx)
     stopCluster(cl)    
   } else {
-    curlHandle <- getCurlHandle()
+    curlHandle <- RCurl::getCurlHandle()
     textoshtmls <- getURL(url = urls, async = FALSE, curl = curlHandle)
     rm(curlHandle)
   }
@@ -411,7 +411,7 @@ descargarArchivo <- function(
             
             if (!useCurl) {
               # Reset handle if there's any error
-              threadHandle <- getCurlHandle(.opts = curlOpts)
+              threadHandle <- RCurl::getCurlHandle(.opts = curlOpts)
             }
           } else { 
             do_download <- FALSE
@@ -514,7 +514,7 @@ descargarArchivos <- function(
           require('curl')
         } else {
           require('RCurl')
-          threadHandle <- getCurlHandle(.opts = curlOpts)
+          threadHandle <- RCurl::getCurlHandle(.opts = curlOpts)
         }
       })
       
@@ -526,7 +526,7 @@ descargarArchivos <- function(
       stopCluster(cl)
     } else {
       if (!useCurl) { 
-        assign("threadHandle", getCurlHandle(.opts=curlOpts), envir=.GlobalEnv)
+        assign("threadHandle", RCurl::getCurlHandle(.opts=curlOpts), envir=.GlobalEnv)
       }
       results <- sapply(
         X=seq_along(urls), FUN=descargarArchivo, urls=urls,

--- a/instalarPaquetes/instant_pkgs.r
+++ b/instalarPaquetes/instant_pkgs.r
@@ -91,7 +91,7 @@ checkInstallPackages <- function(pkgs, minVersions) {
   return(bPaquetesAInstalar)
 }
 
-instant_pkgs <- function(pkgs, minVersions=rep(NA_character_, length(pkgs)), silent=TRUE, doCargarPaquetes=TRUE) {
+instant_pkgs <- function(pkgs, minVersions=rep(NA_character_, length(pkgs)), silent=TRUE, type=type, doCargarPaquetes=TRUE) {
   if (length(pkgs) > 0) {
     bPaquetesAInstalar <- checkInstallPackages(pkgs, minVersions)
     paquetesAInstalar <- pkgs[bPaquetesAInstalar]
@@ -210,9 +210,10 @@ if (!exists('installedPackagesChecked') && file.exists(minPkgVersionsPath)) {
 installedPackagesChecked <- TRUE
 
 createMinPackageVersions <- function() {
-  packages <-installed.packages()
+  packages <- installed.packages()
   write.table(x = packages, file = minPkgVersionsPath, sep='\t', row.names = T, col.names = T, 
               fileEncoding = 'UTF-8')
 }
 
 # renv::snapshot(type="all")
+# 

--- a/instalarPaquetes/instant_pkgs.r
+++ b/instalarPaquetes/instant_pkgs.r
@@ -91,8 +91,31 @@ checkInstallPackages <- function(pkgs, minVersions) {
   return(bPaquetesAInstalar)
 }
 
+write_packages_to_file <- function(pkgs) {
+  file_path <- "required_packages.txt"
+  
+  # Check if the file exists
+  if (!file.exists(file_path)) {
+    # If the file doesn't exist, create it and write all unique package names
+    writeLines(sort(unique(pkgs)), file_path)
+  } else {
+    # If the file exists, read existing package names
+    existing_packages <- readLines(file_path)
+    
+    # Identify unique package names not already in the file
+    new_packages <- unique(sort(c(pkgs, existing_packages)))
+    
+    # Append the new package names to the file
+    writeLines(new_packages, file_path)
+  }
+}
+
 instant_pkgs <- function(pkgs, minVersions=rep(NA_character_, length(pkgs)), silent=TRUE, type=type, doCargarPaquetes=TRUE) {
-  if (length(pkgs) > 0) {
+  if (length(pkgs) > 0 && interactive()) {
+    if (options("instant_pkgs_write_packages_to_file")[[1]]) {
+      write_packages_to_file(pkgs)
+    }
+    
     bPaquetesAInstalar <- checkInstallPackages(pkgs, minVersions)
     paquetesAInstalar <- pkgs[bPaquetesAInstalar]
 

--- a/instalarPaquetes/instant_pkgs.r
+++ b/instalarPaquetes/instant_pkgs.r
@@ -111,8 +111,12 @@ write_packages_to_file <- function(pkgs) {
 }
 
 instant_pkgs <- function(pkgs, minVersions=rep(NA_character_, length(pkgs)), silent=TRUE, type=type, doCargarPaquetes=TRUE) {
-  if (length(pkgs) > 0 && interactive()) {
-    if (options("instant_pkgs_write_packages_to_file")[[1]]) {
+  if (length(pkgs) > 0) {
+    instant_pkgs_write_packages_to_file <- (
+      !is.null(options("instant_pkgs_write_packages_to_file")[[1]]) && 
+        options("instant_pkgs_write_packages_to_file")[[1]]
+    )
+    if (instant_pkgs_write_packages_to_file && interactive()) {
       write_packages_to_file(pkgs)
     }
     

--- a/instalarPaquetes/min_pkg_versions.tsv
+++ b/instalarPaquetes/min_pkg_versions.tsv
@@ -1,731 +1,796 @@
 "Package"	"LibPath"	"Version"	"Priority"	"Depends"	"Imports"	"LinkingTo"	"Suggests"	"Enhances"	"License"	"License_is_FOSS"	"License_restricts_use"	"OS_type"	"MD5sum"	"NeedsCompilation"	"Built"
-"abind"	"abind"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4-5"	NA	"R (>= 1.5.0)"	"methods, utils"	NA	NA	NA	"LGPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"AICcmodavg"	"AICcmodavg"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3-1"	NA	"R (>= 3.2.0)"	"methods, stats, graphics, lattice, MASS, Matrix, nlme, stats4,
+"abind"	"abind"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4-5"	NA	"R (>= 1.5.0)"	"methods, utils"	NA	NA	NA	"LGPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
+"AICcmodavg"	"AICcmodavg"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3-2"	NA	"R (>= 3.2.0)"	"methods, stats, graphics, lattice, MASS, Matrix, nlme, stats4,
 survival, unmarked, VGAM, xtable"	NA	"betareg, coxme, fitdistrplus, glmmTMB, lavaan, lme4, maxlike,
 nnet, ordinal, pscl, R2jags, R2OpenBUGS, R2WinBUGS, jagsUI,
-lmerTest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"akima"	"akima"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6-3.4"	NA	"R (>= 2.0.0)"	"sp"	NA	NA	"tripack"	"ACM | file LICENSE"	NA	"yes"	NA	NA	"yes"	"4.2.0"
-"alphahull"	"alphahull"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.4"	NA	NA	"ggplot2, tripack, R.utils, sgeostat, spatstat.geom,
-spatstat.random, splancs"	NA	NA	NA	"ACM"	NA	NA	NA	NA	"no"	"4.2.0"
-"ape"	"ape"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"5.6-2"	NA	"R (>= 3.2.0)"	"nlme, lattice, graphics, methods, stats, tools, utils,
-parallel, Rcpp (>= 0.12.0)"	"Rcpp"	"gee, expm, igraph, phangorn"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"askpass"	"askpass"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1"	NA	NA	"sys (>= 2.1)"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"assertthat"	"assertthat"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.1"	NA	NA	"tools"	NA	"testthat, covr"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"automap"	"automap"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-16"	NA	"R (>= 2.10.0), sp (>= 0.9-55)"	"gstat, lattice, reshape, methods, ggplot2, maptools"	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"backports"	"backports"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.1"	NA	"R (>= 3.0.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"base64enc"	"base64enc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1-3"	NA	"R (>= 2.9.0)"	NA	NA	NA	"png"	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"bdsmatrix"	"bdsmatrix"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3-4"	NA	"methods, R (>= 2.0.0)"	NA	NA	NA	NA	"LGPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"beeswarm"	"beeswarm"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.0"	NA	NA	"stats, graphics, grDevices, utils"	NA	NA	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"benchmarkme"	"benchmarkme"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.7"	NA	"R (>= 3.5.0)"	"benchmarkmeData (>= 1.0.4), compiler, doParallel, dplyr,
-foreach, graphics, httr, Matrix, methods, parallel, tibble,
-utils"	NA	"covr, DT, ggplot2, knitr, RcppZiggurat, rmarkdown, testthat"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"benchmarkmeData"	"benchmarkmeData"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.4"	NA	"R (>= 3.5.0)"	"dplyr, graphics, tibble, utils"	NA	"benchmarkme, covr, DT, testthat"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"betareg"	"betareg"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1-4"	NA	"R (>= 3.0.0)"	"graphics, grDevices, methods, stats, flexmix, Formula, lmtest,
-modeltools, sandwich"	NA	"car, lattice, partykit, strucchange"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"biglm"	"biglm"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9-2.1"	NA	"DBI, methods"	NA	NA	"RSQLite, RODBC"	"leaps"	"GPL"	NA	NA	NA	NA	"yes"	"4.2.0"
-"BiocManager"	"BiocManager"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.30.18"	NA	NA	"utils"	NA	"BiocVersion, remotes, rmarkdown, testthat, withr, curl, knitr"	NA	"Artistic-2.0"	NA	NA	NA	NA	"no"	"4.2.0"
-"bit"	"bit"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.0.4"	NA	"R (>= 2.9.2)"	NA	NA	"testthat (>= 0.11.0), roxygen2, knitr, rmarkdown,
-microbenchmark, bit64 (>= 4.0.0), ff (>= 4.0.0)"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"bit64"	"bit64"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.0.5"	NA	"R (>= 3.0.1), bit (>= 4.0.0), utils, methods, stats"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"bitops"	"bitops"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-7"	NA	NA	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"blob"	"blob"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.3"	NA	NA	"methods, rlang, vctrs (>= 0.2.1)"	NA	"covr, crayon, pillar (>= 1.2.1), testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"bold"	"bold"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	NA	"xml2, crul (>= 0.3.8), stringr, jsonlite, reshape, plyr,
-data.table, tibble"	NA	"sangerseqR, testthat, vcr (>= 0.5.4)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"brew"	"brew"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-7"	NA	NA	NA	NA	"testthat"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"brio"	"brio"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.3"	NA	NA	NA	NA	"covr, testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"broom"	"broom"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8.0"	NA	"R (>= 3.1)"	"backports, dplyr (>= 1.0.0), ellipsis, generics (>= 0.0.2),
-glue, methods, purrr, rlang, stringr, tibble (>= 3.0.0), tidyr
-(>= 1.0.0), ggplot2"	NA	"AER, akima, AUC, bbmle, betareg, biglm, binGroup, boot,
-btergm (>= 1.10.6), car, caret, cluster, cmprsk, coda, covr,
-drc, e1071, emmeans, epiR, ergm (>= 3.10.4), fixest (>= 0.9.0),
-gam (>= 1.15), gee, geepack, glmnet, glmnetUtils, gmm, Hmisc,
-irlba, joineRML, Kendall, knitr, ks, Lahman, lavaan, leaps,
-lfe, lm.beta, lme4, lmodel2, lmtest (>= 0.9.38), lsmeans, maps,
-maptools, margins, MASS, Matrix, mclust, mediation, metafor,
-mfx, mgcv, mlogit, modeldata, modeltests, muhaz, multcomp,
-network, nnet, orcutt (>= 2.2), ordinal, plm, poLCA, psych,
-quantreg, rgeos, rmarkdown, robust, robustbase, rsample,
-sandwich, sp, spdep (>= 1.1), spatialreg, speedglm, spelling,
-survey, survival, systemfit, testthat (>= 2.1.0), tseries,
-vars, zoo"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"bslib"	"bslib"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.1"	NA	"R (>= 2.10)"	"grDevices, htmltools (>= 0.5.2), jsonlite, sass (>= 0.4.0),
-jquerylib (>= 0.1.3), rlang"	NA	"shiny (>= 1.6.0), rmarkdown (>= 2.7), thematic, knitr,
-testthat, withr, rappdirs, curl, magrittr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"cachem"	"cachem"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.6"	NA	NA	"rlang, fastmap"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"Cairo"	"Cairo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-15"	NA	"R (>= 2.4.0)"	"grDevices, graphics"	NA	"png"	"FastRWeb"	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"callr"	"callr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.7.0"	NA	NA	"processx (>= 3.5.0), R6, utils"	NA	"cli, covr, ps, rprojroot, spelling, testthat, withr (>=
-2.3.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"car"	"car"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.0-13"	NA	"R (>= 3.5.0), carData (>= 3.0-0)"	"abind, MASS, mgcv, nnet, pbkrtest (>= 0.4-4), quantreg,
-grDevices, utils, stats, graphics, maptools, lme4 (>=
-1.1-27.1), nlme"	NA	"alr4, boot, coxme, effects, knitr, leaps, lmtest, Matrix,
-MatrixModels, rgl (>= 0.93.960), rio, sandwich, SparseM,
-survival, survey"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"carData"	"carData"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.0-5"	NA	"R (>= 3.5.0)"	NA	NA	"car (>= 3.0-0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"catdata"	"catdata"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.2"	NA	"MASS"	NA	NA	"rms, qvcalc, glmmML, nnet, pscl, VGAM, gee, mlogit, Ecdat,
+lmerTest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"akima"	"akima"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6-3.4"	NA	"R (>= 2.0.0)"	"sp"	NA	NA	"tripack"	"ACM | file LICENSE"	NA	"yes"	NA	NA	"yes"	"4.2.3"
+"alphahull"	"alphahull"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.5"	NA	NA	"ggplot2, interp, R.utils, sgeostat, spatstat.geom,
+spatstat.random, splancs"	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"ape"	"ape"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"5.7-1"	NA	"R (>= 3.2.0)"	"nlme, lattice, graphics, methods, stats, utils, parallel, Rcpp
+(>= 0.12.0), digest"	"Rcpp"	"gee, expm, igraph, phangorn"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"askpass"	"askpass"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1"	NA	NA	"sys (>= 2.1)"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"assertthat"	"assertthat"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.1"	NA	NA	"tools"	NA	"testthat, covr"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"automap"	"automap"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-9"	NA	"R (>= 2.10.0)"	"gstat, lattice, reshape, methods, ggplot2, sp, sf, stars,
+graphics"	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"av"	"av"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.8.2"	NA	"R (>= 3.5)"	"graphics"	NA	"testthat, ps, ggplot2, gapminder"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.2"
+"backports"	"backports"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.1"	NA	"R (>= 3.0.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
+"base64enc"	"base64enc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-3"	NA	"R (>= 2.9.0)"	NA	NA	NA	"png"	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
+"bdsmatrix"	"bdsmatrix"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3-6"	NA	"methods, R (>= 2.0.0)"	NA	NA	NA	NA	"LGPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
+"beeswarm"	"beeswarm"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.0"	NA	NA	"stats, graphics, grDevices, utils"	NA	NA	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
+"benchmarkme"	"benchmarkme"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.8"	NA	"R (>= 3.5.0)"	"benchmarkmeData (>= 1.0.4), compiler, doParallel, dplyr,
+foreach, graphics, httr, Matrix, methods, parallel, stringr,
+tibble, utils"	NA	"covr, DT, ggplot2, knitr, RcppZiggurat, rmarkdown, testthat"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"benchmarkmeData"	"benchmarkmeData"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.4"	NA	"R (>= 3.5.0)"	"dplyr, graphics, tibble, utils"	NA	"benchmarkme, covr, DT, testthat"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"betareg"	"betareg"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1-4"	NA	"R (>= 3.0.0)"	"graphics, grDevices, methods, stats, flexmix, Formula, lmtest,
+modeltools, sandwich"	NA	"car, lattice, partykit, strucchange"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"biglm"	"biglm"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9-2.1"	NA	"DBI, methods"	NA	NA	"RSQLite, RODBC"	"leaps"	"GPL"	NA	NA	NA	NA	"yes"	"4.2.3"
+"bit"	"bit"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.0.5"	NA	"R (>= 2.9.2)"	NA	NA	"testthat (>= 0.11.0), roxygen2, knitr, rmarkdown,
+microbenchmark, bit64 (>= 4.0.0), ff (>= 4.0.0)"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"bit64"	"bit64"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.0.5"	NA	"R (>= 3.0.1), bit (>= 4.0.0), utils, methods, stats"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"bitops"	"bitops"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-7"	NA	NA	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
+"blob"	"blob"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.4"	NA	NA	"methods, rlang, vctrs (>= 0.2.1)"	NA	"covr, crayon, pillar (>= 1.2.1), testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"bold"	"bold"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.0"	NA	"R (>= 2.10)"	"xml2, crul (>= 0.3.8), stringi, jsonlite, data.table, methods"	NA	"sangerseqR, testthat, vcr (>= 0.5.4), tibble"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"brew"	"brew"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-8"	NA	NA	NA	NA	"testthat (>= 3.0.0)"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"brio"	"brio"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.3"	NA	NA	NA	NA	"covr, testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"broom"	"broom"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.5"	NA	"R (>= 3.5)"	"backports, dplyr (>= 1.0.0), ellipsis, generics (>= 0.0.2),
+glue, lifecycle, purrr, rlang, stringr, tibble (>= 3.0.0),
+tidyr (>= 1.0.0)"	NA	"AER, AUC, bbmle, betareg, biglm, binGroup, boot, btergm (>=
+1.10.6), car, carData, caret, cluster, cmprsk, coda, covr, drc,
+e1071, emmeans, epiR, ergm (>= 3.10.4), fixest (>= 0.9.0), gam
+(>= 1.15), gee, geepack, ggplot2, glmnet, glmnetUtils, gmm,
+Hmisc, irlba, interp, joineRML, Kendall, knitr, ks, Lahman,
+lavaan, leaps, lfe, lm.beta, lme4, lmodel2, lmtest (>= 0.9.38),
+lsmeans, maps, margins, MASS, mclust, mediation, metafor, mfx,
+mgcv, mlogit, modeldata, modeltests, muhaz, multcomp, network,
+nnet, orcutt (>= 2.2), ordinal, plm, poLCA, psych, quantreg,
+rmarkdown, robust, robustbase, rsample, sandwich, sp, spdep (>=
+1.1), spatialreg, speedglm, spelling, survey, survival,
+systemfit, testthat (>= 2.1.0), tseries, vars, zoo"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"bslib"	"bslib"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.0"	NA	"R (>= 2.10)"	"base64enc, cachem, grDevices, htmltools (>= 0.5.4), jquerylib
+(>= 0.1.3), jsonlite, memoise (>= 2.0.1), mime, rlang, sass (>=
+0.4.0)"	NA	"bsicons, curl, fontawesome, ggplot2, knitr, magrittr,
+rappdirs, rmarkdown (>= 2.7), shiny (>= 1.6.0), testthat,
+thematic, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"cachem"	"cachem"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.8"	NA	NA	"rlang, fastmap (>= 1.1.1)"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"Cairo"	"Cairo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6-0"	NA	"R (>= 2.4.0)"	"grDevices, graphics"	NA	"png"	"FastRWeb"	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"callr"	"callr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.7.3"	NA	"R (>= 3.4)"	"processx (>= 3.6.1), R6, utils"	NA	"asciicast, cli (>= 1.1.0), covr, mockery, ps, rprojroot,
+spelling, testthat (>= 3.0.0), withr (>= 2.3.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"car"	"car"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1-2"	NA	"R (>= 3.5.0), carData (>= 3.0-0)"	"abind, MASS, mgcv, nnet, pbkrtest (>= 0.4-4), quantreg,
+grDevices, utils, stats, graphics, lme4 (>= 1.1-27.1), nlme,
+scales"	NA	"alr4, boot, coxme, effects, knitr, leaps, lmtest, Matrix,
+MatrixModels, mvtnorm, rgl (>= 0.111.3), rio, sandwich,
+SparseM, survival, survey"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"carData"	"carData"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.0-5"	NA	"R (>= 3.5.0)"	NA	NA	"car (>= 3.0-0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"catdata"	"catdata"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.3"	NA	"MASS"	NA	NA	"rms, qvcalc, glmmML, nnet, pscl, VGAM, gee, mlogit, Ecdat,
 geepack, mgcv, rpart, party, ordinal, lme4, vcdExtra, glmnet,
-mboost, class, e1071, flexmix, lpSolve, GAMBoost, penalized"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"caTools"	"caTools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.18.2"	NA	"R (>= 3.6.0)"	"bitops"	NA	"MASS, rpart"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"checkmate"	"checkmate"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.0"	NA	"R (>= 3.0.0)"	"backports (>= 1.1.0), utils"	NA	"R6, fastmatch, data.table (>= 1.9.8), devtools, ggplot2,
+mboost, class, e1071, flexmix, lpSolve, penalized"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"caTools"	"caTools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.18.2"	NA	"R (>= 3.6.0)"	"bitops"	NA	"MASS, rpart"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"checkmate"	"checkmate"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.2.0"	NA	"R (>= 3.0.0)"	"backports (>= 1.1.0), utils"	NA	"R6, fastmatch, data.table (>= 1.9.8), devtools, ggplot2,
 knitr, magrittr, microbenchmark, rmarkdown, testthat (>=
-3.0.4), tinytest (>= 1.1.0), tibble"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"classInt"	"classInt"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4-3"	NA	"R (>= 2.2)"	"grDevices, stats, graphics, e1071, class, KernSmooth"	NA	"spData (>= 0.2.6.2), units, knitr, rmarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"cli"	"cli"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.3.0"	NA	"R (>= 3.4)"	"glue (>= 1.6.0), utils"	NA	"asciicast, callr, covr, digest, grDevices, htmltools,
-htmlwidgets, knitr, methods, mockery, processx, ps (>=
-1.3.4.9000), rlang, rmarkdown, rstudioapi, shiny, testthat,
-tibble, whoami, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"clipr"	"clipr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8.0"	NA	NA	"utils"	NA	"covr, knitr, rmarkdown, rstudioapi (>= 0.5), testthat (>=
-2.0.0)"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"coda"	"coda"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.19-4"	NA	"R (>= 2.14.0)"	"lattice"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"colorspace"	"colorspace"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0-3"	NA	"R (>= 3.0.0), methods"	"graphics, grDevices, stats"	NA	"datasets, utils, KernSmooth, MASS, kernlab, mvtnorm, vcd,
+3.0.4), tinytest (>= 1.1.0), tibble"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"classInt"	"classInt"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4-9"	NA	"R (>= 2.2)"	"grDevices, stats, graphics, e1071, class, KernSmooth"	NA	"spData (>= 0.2.6.2), units, knitr, rmarkdown, tinytest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"cli"	"cli"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.6.1"	NA	"R (>= 3.4)"	"utils"	NA	"callr, covr, crayon, digest, glue (>= 1.6.0), grDevices,
+htmltools, htmlwidgets, knitr, methods, mockery, processx, ps
+(>= 1.3.4.9000), rlang (>= 1.0.2.9003), rmarkdown, rprojroot,
+rstudioapi, testthat, tibble, whoami, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"clipr"	"clipr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.8.0"	NA	NA	"utils"	NA	"covr, knitr, rmarkdown, rstudioapi (>= 0.5), testthat (>=
+2.0.0)"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"coda"	"coda"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.19-4"	NA	"R (>= 2.14.0)"	"lattice"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"colorspace"	"colorspace"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1-0"	NA	"R (>= 3.0.0), methods"	"graphics, grDevices, stats"	NA	"datasets, utils, KernSmooth, MASS, kernlab, mvtnorm, vcd,
 tcltk, shiny, shinyjs, ggplot2, dplyr, scales, grid, png, jpeg,
 knitr, rmarkdown, RColorBrewer, rcartocolor, scico, viridis,
-wesanderson"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"commonmark"	"commonmark"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.0"	NA	NA	NA	NA	"curl, testthat, xml2"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"conditionz"	"conditionz"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.0"	NA	"R(>= 3.2.1)"	"R6, uuid"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"covr"	"covr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.5.1"	NA	"R (>= 3.1.0), methods"	"digest, stats, utils, jsonlite, rex, httr, crayon, withr (>=
+wesanderson"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"commonmark"	"commonmark"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.0"	NA	NA	NA	NA	"curl, testthat, xml2"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"conditionz"	"conditionz"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.0"	NA	"R(>= 3.2.1)"	"R6, uuid"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"covr"	"covr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.6.2"	NA	"R (>= 3.1.0), methods"	"digest, stats, utils, jsonlite, rex, httr, crayon, withr (>=
 1.0.2), yaml"	NA	"R6, curl, knitr, rmarkdown, htmltools, DT (>= 0.2), testthat,
 rlang, rstudioapi (>= 0.2), xml2 (>= 1.0.0), parallel, memoise,
-mockery"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"coxme"	"coxme"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2-16"	"optional"	"survival (>= 2.36.14), methods, bdsmatrix(>= 1.3), R(>= 2.10)"	"nlme, Matrix (>= 1.0)"	"bdsmatrix"	"mvtnorm, kinship2"	NA	"LGPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"crayon"	"crayon"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.1"	NA	NA	"grDevices, methods, utils"	NA	"mockery, rstudioapi, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"credentials"	"credentials"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.2"	NA	NA	"openssl (>= 1.3), sys (>= 2.1), curl, jsonlite, askpass"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"crosstalk"	"crosstalk"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	NA	"htmltools (>= 0.3.6), jsonlite, lazyeval, R6"	NA	"shiny, ggplot2, testthat (>= 2.1.0), sass, bslib"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"crul"	"crul"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	NA	"curl (>= 3.3), R6 (>= 2.2.0), urltools (>= 1.6.0), httpcode
+mockery, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"coxme"	"coxme"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.2-18.1"	"optional"	"survival (>= 2.36.14), methods, bdsmatrix(>= 1.3), R(>= 2.10)"	"nlme, Matrix (>= 1.0)"	"bdsmatrix"	"mvtnorm, kinship2"	NA	"LGPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"crayon"	"crayon"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.2"	NA	NA	"grDevices, methods, utils"	NA	"mockery, rstudioapi, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"credentials"	"credentials"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.2"	NA	NA	"openssl (>= 1.3), sys (>= 2.1), curl, jsonlite, askpass"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"crosstalk"	"crosstalk"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.0"	NA	NA	"htmltools (>= 0.3.6), jsonlite, lazyeval, R6"	NA	"shiny, ggplot2, testthat (>= 2.1.0), sass, bslib"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"crul"	"crul"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.0"	NA	NA	"curl (>= 3.3), R6 (>= 2.2.0), urltools (>= 1.6.0), httpcode
 (>= 0.2.0), jsonlite, mime"	NA	"testthat, roxygen2 (>= 7.1.1), fauxpas (>= 0.1.0), webmockr
-(>= 0.1.0), knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"curl"	"curl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.3.2"	NA	"R (>= 3.0.0)"	NA	NA	"spelling, testthat (>= 1.0.0), knitr, jsonlite, rmarkdown,
-magrittr, httpuv (>= 1.4.4), webutils"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"data.table"	"data.table"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.14.2"	NA	"R (>= 3.1.0)"	"methods"	NA	"bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts,
-nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown"	NA	"MPL-2.0 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"DBI"	"DBI"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.2"	NA	"methods, R (>= 3.0.0)"	NA	NA	"blob, covr, DBItest, dbplyr, downlit, dplyr, glue, hms,
+(>= 0.1.0), knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"curl"	"curl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"5.0.1"	NA	"R (>= 3.0.0)"	NA	NA	"spelling, testthat (>= 1.0.0), knitr, jsonlite, rmarkdown,
+magrittr, httpuv (>= 1.4.4), webutils"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"data.table"	"data.table"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.14.8"	NA	"R (>= 3.1.0)"	"methods"	NA	"bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts,
+nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown"	NA	"MPL-2.0 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"DBI"	"DBI"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.3"	NA	"methods, R (>= 3.0.0)"	NA	NA	"blob, covr, DBItest, dbplyr, downlit, dplyr, glue, hms,
 knitr, magrittr, RMariaDB, rmarkdown, rprojroot, RSQLite (>=
-1.1-2), testthat, xml2"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"deldir"	"deldir"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-6"	NA	"R (>= 3.5.0)"	"graphics, grDevices"	NA	"polyclip"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"DEoptimR"	"DEoptimR"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-11"	NA	NA	"stats"	NA	NA	"robustbase"	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"desc"	"desc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.1"	NA	"R (>= 3.4)"	"cli, R6, rprojroot, utils"	NA	"callr, covr, gh, spelling, testthat, whoami, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"devEMF"	"devEMF"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.0-2"	NA	"R (>= 2.10.1)"	NA	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"devtools"	"devtools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.4.3"	NA	"R (>= 3.0.2), usethis (>= 2.0.1)"	"callr (>= 3.6.0), cli (>= 3.0.0), desc (>= 1.3.0), ellipsis
-(>= 0.3.1), fs (>= 1.5.0), httr (>= 1.4.2), lifecycle (>=
-1.0.0), memoise (>= 2.0.0), pkgbuild (>= 1.2.0), pkgload (>=
-1.2.1), rcmdcheck (>= 1.3.3), remotes (>= 2.3.0), rlang (>=
-0.4.10), roxygen2 (>= 7.1.1), rstudioapi (>= 0.13), rversions
-(>= 2.0.2), sessioninfo (>= 1.1.1), stats, testthat (>= 3.0.2),
-tools, utils, withr (>= 2.4.1)"	NA	"BiocManager (>= 1.30.12), covr (>= 3.5.1), curl (>= 4.3),
-digest (>= 0.6.27), DT (>= 0.17), foghorn (>= 1.3.2), gh (>=
-1.2.1), gmailr (>= 1.0.0), knitr (>= 1.31), lintr (>= 2.0.1),
-MASS, mockery (>= 0.4.2), pingr (>= 2.0.1), pkgdown (>= 1.6.1),
-rhub (>= 1.1.1), rmarkdown (>= 2.7), spelling (>= 2.2)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"diffobj"	"diffobj"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.5"	NA	"R (>= 3.1.0)"	"crayon (>= 1.3.2), tools, methods, utils, stats"	NA	"knitr, rmarkdown"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"digest"	"digest"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6.29"	NA	"R (>= 3.3.0)"	"utils"	NA	"tinytest, simplermarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"directlabels"	"directlabels"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2021.1.13"	NA	NA	"grid, quadprog"	NA	"MASS, knitr, markdown, inlinedocs, RColorBrewer, ggplot2 (>=
+1.1-2), testthat, xml2"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"deldir"	"deldir"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-9"	NA	"R (>= 3.5.0)"	"graphics, grDevices"	NA	"polyclip"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"DEoptimR"	"DEoptimR"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-3"	NA	NA	"stats"	NA	NA	"robustbase"	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"desc"	"desc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.2"	NA	"R (>= 3.4)"	"cli, R6, rprojroot, utils"	NA	"callr, covr, gh, spelling, testthat, whoami, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"devEMF"	"devEMF"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.4-1"	NA	"R (>= 2.10.1)"	NA	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"devtools"	"devtools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.4.5"	NA	"R (>= 3.0.2), usethis (>= 2.1.6)"	"cli (>= 3.3.0), desc (>= 1.4.1), ellipsis (>= 0.3.2), fs (>=
+1.5.2), lifecycle (>= 1.0.1), memoise (>= 2.0.1), miniUI (>=
+0.1.1.1), pkgbuild (>= 1.3.1), pkgdown (>= 2.0.6), pkgload (>=
+1.3.0), profvis (>= 0.3.7), rcmdcheck (>= 1.4.0), remotes (>=
+2.4.2), rlang (>= 1.0.4), roxygen2 (>= 7.2.1), rversions (>=
+2.1.1), sessioninfo (>= 1.2.2), stats, testthat (>= 3.1.5),
+tools, urlchecker (>= 1.0.1), utils, withr (>= 2.5.0)"	NA	"BiocManager (>= 1.30.18), callr (>= 3.7.1), covr (>= 3.5.1),
+curl (>= 4.3.2), digest (>= 0.6.29), DT (>= 0.23), foghorn (>=
+1.4.2), gh (>= 1.3.0), gmailr (>= 1.0.1), httr (>= 1.4.3),
+knitr (>= 1.39), lintr (>= 3.0.0), MASS, mockery (>= 0.4.3),
+pingr (>= 2.0.1), rhub (>= 1.1.1), rmarkdown (>= 2.14),
+rstudioapi (>= 0.13), spelling (>= 2.2)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"diffobj"	"diffobj"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.5"	NA	"R (>= 3.1.0)"	"crayon (>= 1.3.2), tools, methods, utils, stats"	NA	"knitr, rmarkdown"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"digest"	"digest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6.33"	NA	"R (>= 3.3.0)"	"utils"	NA	"tinytest, simplermarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"directlabels"	"directlabels"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2021.1.13"	NA	NA	"grid, quadprog"	NA	"MASS, knitr, markdown, inlinedocs, RColorBrewer, ggplot2 (>=
 2.0), rlang, lattice, alphahull, nlme, lars, latticeExtra,
-dplyr, ggthemes, testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"doParallel"	"doParallel"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.17"	NA	"R (>= 2.14.0), foreach (>= 1.2.0), iterators (>= 1.0.0),
-parallel, utils"	NA	NA	"caret, mlbench, rpart, RUnit"	"compiler"	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"doRNG"	"doRNG"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.2"	NA	"R (>= 3.0.0), foreach, rngtools (>= 1.5)"	"stats, utils, iterators"	NA	"doParallel, doMPI, doRedis, rbenchmark, devtools, knitr,
-bibtex, testthat, pkgmaker (>= 0.31)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"dotCall64"	"dotCall64"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-1"	NA	"R (>= 3.1)"	NA	NA	"microbenchmark, OpenMPController, RColorBrewer, roxygen2,
-spam, testthat,"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"downlit"	"downlit"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.0"	NA	"R (>= 3.4.0)"	"brio, desc, digest, evaluate, fansi, memoise, rlang, vctrs,
-yaml"	NA	"covr, htmltools, jsonlite, leaflet, MASS, pkgload, rmarkdown,
-testthat (>= 3.0.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"dplyr"	"dplyr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.9"	NA	"R (>= 3.4.0)"	"generics, glue (>= 1.3.2), lifecycle (>= 1.0.1), magrittr (>=
-1.5), methods, R6, rlang (>= 1.0.2), tibble (>= 2.1.3),
-tidyselect (>= 1.1.1), utils, vctrs (>= 0.4.1), pillar (>=
-1.5.1)"	NA	"bench, broom, callr, covr, DBI, dbplyr (>= 1.4.3), ggplot2,
+dplyr, ggthemes, testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"doParallel"	"doParallel"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.17"	NA	"R (>= 2.14.0), foreach (>= 1.2.0), iterators (>= 1.0.0),
+parallel, utils"	NA	NA	"caret, mlbench, rpart, RUnit"	"compiler"	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"doRNG"	"doRNG"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8.6"	NA	"R (>= 3.0.0), foreach, rngtools (>= 1.5)"	"stats, utils, iterators"	NA	"doParallel, doMPI, doRedis, rbenchmark, devtools, knitr,
+rbibutils (>= 1.3), testthat, pkgmaker (>= 0.32.7), covr"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"dotCall64"	"dotCall64"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-2"	NA	"R (>= 3.1)"	NA	NA	"microbenchmark, OpenMPController, RColorBrewer, roxygen2,
+spam, testthat,"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"downlit"	"downlit"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.3"	NA	"R (>= 3.4.0)"	"brio, desc, digest, evaluate, fansi, memoise, rlang, vctrs,
+withr, yaml"	NA	"covr, htmltools, jsonlite, MASS, MassSpecWavelet, pkgload,
+rmarkdown, testthat (>= 3.0.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"dplyr"	"dplyr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.2"	NA	"R (>= 3.5.0)"	"cli (>= 3.4.0), generics, glue (>= 1.3.2), lifecycle (>=
+1.0.3), magrittr (>= 1.5), methods, pillar (>= 1.9.0), R6,
+rlang (>= 1.1.0), tibble (>= 3.2.0), tidyselect (>= 1.2.0),
+utils, vctrs (>= 0.6.0)"	NA	"bench, broom, callr, covr, DBI, dbplyr (>= 2.2.1), ggplot2,
 knitr, Lahman, lobstr, microbenchmark, nycflights13, purrr,
-rmarkdown, RMySQL, RPostgreSQL, RSQLite, testthat (>= 3.1.1),
-tidyr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"DT"	"DT"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.23"	NA	NA	"htmltools (>= 0.3.6), htmlwidgets (>= 1.3), jsonlite (>=
-0.9.16), magrittr, crosstalk, jquerylib, promises"	NA	"knitr (>= 1.8), rmarkdown, shiny (>= 1.6), bslib, testit"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"e1071"	"e1071"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7-9"	NA	NA	"graphics, grDevices, class, stats, methods, utils, proxy"	NA	"cluster, mlbench, nnet, randomForest, rpart, SparseM, xtable,
-Matrix, MASS, slam"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ellipsis"	"ellipsis"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.2"	NA	"R (>= 3.2)"	"rlang (>= 0.3.0)"	NA	"covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"equate"	"equate"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.7"	NA	"R (>= 3.4.0)"	"utils, grDevices, graphics, stats"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"evaluate"	"evaluate"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.15"	NA	"R (>= 3.0.2)"	"methods"	NA	"covr, ggplot2, lattice, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"evd"	"evd"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3-6"	NA	NA	"stats, grDevices, graphics"	NA	"akima"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"fansi"	"fansi"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.3"	NA	"R (>= 3.1.0)"	"grDevices, utils"	NA	"unitizer, knitr, rmarkdown"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"farver"	"farver"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.0"	NA	NA	NA	NA	"testthat (>= 2.1.0), covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"fastmap"	"fastmap"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.0"	NA	NA	NA	NA	"testthat (>= 2.1.1)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"fastmatch"	"fastmatch"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-3"	NA	"R (>= 2.3.0)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"fields"	"fields"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"13.3"	NA	"R (>= 3.0), methods, spam, viridis"	"maps"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"fit.models"	"fit.models"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.64"	NA	NA	"lattice, stats"	NA	"MASS"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"fitdistrplus"	"fitdistrplus"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-8"	NA	"R (>= 3.5.0), MASS, grDevices, survival, methods"	"stats"	NA	"actuar, rgenoud, mc2d, gamlss.dist, knitr, ggplot2,
-GeneralizedHyperbolic, rmarkdown, Hmisc"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"flexmix"	"flexmix"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3-17"	NA	"R (>= 2.15.0), lattice"	"graphics, grid, grDevices, methods, modeltools (>= 0.2-16),
+rmarkdown, RMySQL, RPostgreSQL, RSQLite, stringi (>= 1.7.6),
+testthat (>= 3.1.5), tidyr (>= 1.3.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"DT"	"DT"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.28"	NA	NA	"htmltools (>= 0.3.6), htmlwidgets (>= 1.3), jsonlite (>=
+0.9.16), magrittr, crosstalk, jquerylib, promises"	NA	"knitr (>= 1.8), rmarkdown, shiny (>= 1.6), bslib, future,
+testit, tibble"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"e1071"	"e1071"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7-13"	NA	NA	"graphics, grDevices, class, stats, methods, utils, proxy"	NA	"cluster, mlbench, nnet, randomForest, rpart, SparseM, xtable,
+Matrix, MASS, slam"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ellipsis"	"ellipsis"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.2"	NA	"R (>= 3.2)"	"rlang (>= 0.3.0)"	NA	"covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"equate"	"equate"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.8"	NA	"R (>= 4.1.0)"	"utils, grDevices, graphics, stats"	NA	"knitr, rmarkdown, bookdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"evaluate"	"evaluate"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.21"	NA	"R (>= 3.0.2)"	"methods"	NA	"covr, ggplot2, lattice, rlang, testthat (>= 3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"evd"	"evd"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3-6.1"	NA	NA	"stats, grDevices, graphics"	NA	"interp"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"fansi"	"fansi"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.4"	NA	"R (>= 3.1.0)"	"grDevices, utils"	NA	"unitizer, knitr, rmarkdown"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"farver"	"farver"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.1"	NA	NA	NA	NA	"covr, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"fastmap"	"fastmap"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.1"	NA	NA	NA	NA	"testthat (>= 2.1.1)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"fastmatch"	"fastmatch"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-3"	NA	"R (>= 2.3.0)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
+"fields"	"fields"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"14.1"	NA	"R (>= 3.5.0), methods, spam, viridis"	"maps"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"filelock"	"filelock"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.2"	NA	NA	NA	NA	"callr (>= 2.0.0), covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"fit.models"	"fit.models"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.64"	NA	NA	"lattice, stats"	NA	"MASS"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"fitdistrplus"	"fitdistrplus"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-11"	NA	"R (>= 3.5.0), MASS, grDevices, survival, methods"	"stats"	NA	"actuar, rgenoud, mc2d, gamlss.dist, knitr, ggplot2,
+GeneralizedHyperbolic, rmarkdown, Hmisc, bookdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"flexmix"	"flexmix"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3-19"	NA	"R (>= 2.15.0), lattice"	"graphics, grid, grDevices, methods, modeltools (>= 0.2-16),
 nnet, stats, stats4, utils"	NA	"actuar, codetools, diptest, Ecdat, ellipse, gclus, glmnet,
 lme4 (>= 1.1), MASS, mgcv (>= 1.8-0), mlbench, multcomp,
-mvtnorm, SuppDists, survival"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"float"	"float"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3-0"	NA	"R (>= 3.6.0), methods"	"utils, tools"	NA	NA	NA	"BSD 2-clause License + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"FNN"	"FNN"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.3"	NA	"R (>= 3.0.0)"	NA	NA	"chemometrics, mvtnorm"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"forcats"	"forcats"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5.1"	NA	"R (>= 3.2)"	"ellipsis, magrittr, rlang, tibble"	NA	"covr, dplyr, ggplot2, knitr, readr, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"foreach"	"foreach"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.2"	NA	"R (>= 2.5.0)"	"codetools, utils, iterators"	NA	"randomForest, doMC, doParallel, testthat, knitr, rmarkdown"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"no"	"4.2.0"
-"Formula"	"Formula"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2-4"	NA	"R (>= 2.0.0), stats"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"fs"	"fs"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.2"	NA	"R (>= 3.1)"	"methods"	NA	"testthat, covr, pillar (>= 1.0.0), tibble (>= 1.1.0), crayon,
-rmarkdown, knitr, withr, spelling, vctrs (>= 0.3.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"future"	"future"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.25.0"	NA	NA	"digest, globals (>= 0.14.0), listenv (>= 0.8.0), parallel,
-parallelly (>= 1.30.0), tools, utils"	NA	"RhpcBLASctl, R.rsp, markdown"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"future.apply"	"future.apply"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.9.0"	NA	"R (>= 3.2.0), future (>= 1.22.1)"	"globals (>= 0.14.0), parallel, utils"	NA	"datasets, stats, tools, listenv (>= 0.8.0), R.rsp, markdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"generics"	"generics"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.2"	NA	"R (>= 3.2)"	"methods"	NA	"covr, pkgload, testthat (>= 3.0.0), tibble, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"geojsonsf"	"geojsonsf"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.2"	NA	"R (>= 3.3.0)"	"Rcpp"	"geometries, jsonify (>= 1.1.1), rapidjsonr (>= 1.2.0), Rcpp,
-sfheaders (>= 0.2.2)"	"covr, jsonify, knitr, rmarkdown, tinytest"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"gert"	"gert"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.6.0"	NA	NA	"askpass, credentials (>= 1.2.1), openssl (>= 1.4.1),
-rstudioapi (>= 0.11), sys, zip (>= 2.1.0)"	NA	"spelling, knitr, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"GGally"	"GGally"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.2"	NA	"R (>= 3.1), ggplot2 (>= 3.3.4)"	"dplyr (>= 1.0.0), forcats, grDevices, grid, gtable (>= 0.2.0),
+mvtnorm, SuppDists, survival"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"float"	"float"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3-1"	NA	"R (>= 3.6.0), methods"	"utils, tools"	NA	NA	NA	"BSD 2-clause License + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.2"
+"FNN"	"FNN"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.3.2"	NA	"R (>= 3.0.0)"	NA	NA	"chemometrics, mvtnorm"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"fontawesome"	"fontawesome"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.1"	NA	"R (>= 3.3.0)"	"rlang (>= 1.0.6), htmltools (>= 0.5.1.1)"	NA	"covr, dplyr (>= 1.0.8), knitr (>= 1.31), testthat (>= 3.0.0),
+rsvg"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"forcats"	"forcats"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R (>= 3.4)"	"cli (>= 3.4.0), glue, lifecycle, magrittr, rlang (>= 1.0.0),
+tibble"	NA	"covr, dplyr, ggplot2, knitr, readr, rmarkdown, testthat (>=
+3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"foreach"	"foreach"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.2"	NA	"R (>= 2.5.0)"	"codetools, utils, iterators"	NA	"randomForest, doMC, doParallel, testthat, knitr, rmarkdown"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"no"	"4.2.3"
+"Formula"	"Formula"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2-5"	NA	"R (>= 2.0.0), stats"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.2"
+"fs"	"fs"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6.3"	NA	"R (>= 3.4)"	"methods"	NA	"covr, crayon, knitr, pillar (>= 1.0.0), rmarkdown, spelling,
+testthat (>= 3.0.0), tibble (>= 1.1.0), vctrs (>= 0.3.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"future"	"future"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.33.0"	NA	NA	"digest, globals (>= 0.16.1), listenv (>= 0.8.0), parallel,
+parallelly (>= 1.34.0), utils"	NA	"methods, RhpcBLASctl, R.rsp, markdown"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"future.apply"	"future.apply"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.11.0"	NA	"R (>= 3.2.0), future (>= 1.28.0)"	"globals (>= 0.16.1), parallel, utils"	NA	"datasets, stats, tools, listenv (>= 0.8.0), R.rsp, markdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"generics"	"generics"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.3"	NA	"R (>= 3.2)"	"methods"	NA	"covr, pkgload, testthat (>= 3.0.0), tibble, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"geojsonsf"	"geojsonsf"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.3"	NA	"R (>= 3.3.0)"	"Rcpp"	"geometries, jsonify (>= 1.1.1), rapidjsonr (>= 1.2.0), Rcpp,
+sfheaders (>= 0.2.2)"	"covr, jsonify, knitr, rmarkdown, tinytest"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"gert"	"gert"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.2"	NA	NA	"askpass, credentials (>= 1.2.1), openssl (>= 2.0.3),
+rstudioapi (>= 0.11), sys, zip (>= 2.1.0)"	NA	"spelling, knitr, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"GGally"	"GGally"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.2"	NA	"R (>= 3.1), ggplot2 (>= 3.3.4)"	"dplyr (>= 1.0.0), forcats, grDevices, grid, gtable (>= 0.2.0),
 lifecycle, plyr (>= 1.8.3), progress, RColorBrewer, reshape (>=
 0.8.5), rlang, scales (>= 1.1.0), tidyr, utils"	NA	"broom (>= 0.7.0), broom.helpers (>= 1.1.0), chemometrics,
 geosphere (>= 1.5-1), ggforce, Hmisc, igraph (>= 1.0.1),
 intergraph (>= 2.0-2), labelled, maps (>= 3.1.0), mapproj,
 nnet, network (>= 1.17.1), scagnostics, sna (>= 2.3-2),
 survival, rmarkdown, roxygen2, testthat, crosstalk, knitr,
-spelling, emmeans"	NA	"GPL (>= 2.0)"	NA	NA	NA	NA	"no"	"4.2.0"
-"ggbeeswarm"	"ggbeeswarm"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6.0"	NA	"R (>= 3.0.0), ggplot2 (>= 2.0)"	"beeswarm, vipor"	NA	"gridExtra"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"ggplot2"	"ggplot2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.3.6"	NA	"R (>= 3.3)"	"digest, glue, grDevices, grid, gtable (>= 0.1.1), isoband,
-MASS, mgcv, rlang (>= 0.4.10), scales (>= 0.5.0), stats,
-tibble, withr (>= 2.0.0)"	NA	"covr, ragg, dplyr, ggplot2movies, hexbin, Hmisc, interp,
-knitr, lattice, mapproj, maps, maptools, multcomp, munsell,
-nlme, profvis, quantreg, RColorBrewer, rgeos, rmarkdown, rpart,
-sf (>= 0.7-3), svglite (>= 1.2.0.9001), testthat (>= 2.1.0),
-vdiffr (>= 1.0.0), xml2"	"sp"	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"ggrepel"	"ggrepel"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9.1"	NA	"R (>= 3.0.0), ggplot2 (>= 2.2.0)"	"grid, Rcpp, rlang (>= 0.3.0), scales (>= 0.5.0)"	"Rcpp"	"knitr, rmarkdown, testthat, gridExtra, devtools, prettydoc,
-ggbeeswarm, dplyr, magrittr, readr, stringr"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ggthemes"	"ggthemes"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.2.4"	NA	"R (>= 3.3.0)"	"ggplot2 (>= 3.0.0), graphics, grid, methods, purrr, scales,
+spelling, emmeans"	NA	"GPL (>= 2.0)"	NA	NA	NA	NA	"no"	"4.2.3"
+"ggbeeswarm"	"ggbeeswarm"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.7.2"	NA	"R (>= 3.5.0), ggplot2 (>= 3.3.0)"	"beeswarm, lifecycle, vipor, cli"	NA	"gridExtra"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"ggplot2"	"ggplot2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.4.2"	NA	"R (>= 3.3)"	"cli, glue, grDevices, grid, gtable (>= 0.1.1), isoband,
+lifecycle (> 1.0.1), MASS, mgcv, rlang (>= 1.1.0), scales (>=
+1.2.0), stats, tibble, vctrs (>= 0.5.0), withr (>= 2.5.0)"	NA	"covr, dplyr, ggplot2movies, hexbin, Hmisc, knitr, lattice,
+mapproj, maps, maptools, multcomp, munsell, nlme, profvis,
+quantreg, ragg, RColorBrewer, rgeos, rmarkdown, rpart, sf (>=
+0.7-3), svglite (>= 1.2.0.9001), testthat (>= 3.1.2), vdiffr
+(>= 1.0.0), xml2"	"sp"	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"ggrepel"	"ggrepel"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9.3"	NA	"R (>= 3.0.0), ggplot2 (>= 2.2.0)"	"grid, Rcpp, rlang (>= 0.3.0), scales (>= 0.5.0), withr (>=
+2.5.0)"	"Rcpp"	"knitr, rmarkdown, testthat, svglite, vdiffr, gridExtra,
+devtools, prettydoc, ggbeeswarm, dplyr, magrittr, readr,
+stringr"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ggthemes"	"ggthemes"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.2.4"	NA	"R (>= 3.3.0)"	"ggplot2 (>= 3.0.0), graphics, grid, methods, purrr, scales,
 stringr, tibble"	NA	"dplyr, covr, extrafont, glue, knitr, lattice, lintr, maps,
 mapproj, pander, rlang, rmarkdown, spelling, testthat, tidyr,
-vdiffr, withr"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"gh"	"gh"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.0"	NA	NA	"cli (>= 2.0.1), gitcreds, httr (>= 1.2), ini, jsonlite"	NA	"covr, knitr, mockery, rmarkdown, rprojroot, spelling,
-testthat (>= 2.3.2), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"gitcreds"	"gitcreds"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.1"	NA	NA	NA	NA	"codetools, testthat, knitr, mockery, oskeyring, rmarkdown,
-withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"glmmTMB"	"glmmTMB"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.3"	NA	"R (>= 3.2.0)"	"methods, TMB (>= 1.7.14), lme4 (>= 1.1-18.9000), Matrix, nlme,
+vdiffr, withr"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"gh"	"gh"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.0"	NA	"R (>= 3.4)"	"cli (>= 3.0.1), gitcreds, httr2, ini, jsonlite, rlang (>=
+1.0.0)"	NA	"covr, knitr, mockery, rmarkdown, rprojroot, spelling,
+testthat (>= 3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"gitcreds"	"gitcreds"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.2"	NA	"R (>= 3.4)"	NA	NA	"codetools, covr, knitr, mockery, oskeyring, rmarkdown,
+testthat (>= 3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"glmmTMB"	"glmmTMB"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.7"	NA	"R (>= 3.2.0)"	"methods, TMB (>= 1.9.0), lme4 (>= 1.1-18.9000), Matrix, nlme,
 numDeriv"	"TMB, RcppEigen"	"knitr, rmarkdown, testthat, MASS, lattice, ggplot2 (>=
 2.2.1), mlmRev, bbmle (>= 1.0.19), pscl, coda, reshape2, car
 (>= 3.0.6), emmeans (>= 1.4), estimability, DHARMa, multcomp,
 MuMIn, effects (>= 4.0-1), dotwhisker, broom, broom.mixed,
-plyr, png, boot, texreg, xtable, huxtable, mvabund"	NA	"AGPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"glmnet"	"glmnet"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.1-4"	NA	"R (>= 3.6.0), Matrix (>= 1.0-6)"	"methods, utils, foreach, shape, survival, Rcpp"	"RcppEigen, Rcpp"	"knitr, lars, testthat, xfun, rmarkdown"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"globals"	"globals"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.15.0"	NA	"R (>= 3.1.2)"	"codetools"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"glue"	"glue"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.6.2"	NA	"R (>= 3.4)"	"methods"	NA	"covr, crayon, DBI, dplyr, forcats, ggplot2, knitr, magrittr,
+plyr, png, boot, texreg, xtable, huxtable, mvabund, parallel"	NA	"AGPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"glmnet"	"glmnet"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.1-7"	NA	"R (>= 3.6.0), Matrix (>= 1.0-6)"	"methods, utils, foreach, shape, survival, Rcpp"	"RcppEigen, Rcpp"	"knitr, lars, testthat, xfun, rmarkdown"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"globals"	"globals"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.16.2"	NA	"R (>= 3.1.2)"	"codetools"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.2"
+"glue"	"glue"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6.2"	NA	"R (>= 3.4)"	"methods"	NA	"covr, crayon, DBI, dplyr, forcats, ggplot2, knitr, magrittr,
 microbenchmark, R.utils, rmarkdown, rprintf, RSQLite, stringr,
-testthat (>= 3.0.0), vctrs (>= 0.3.0), waldo (>= 0.3.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"gplots"	"gplots"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1.3"	NA	"R (>= 3.0)"	"gtools, stats, caTools, KernSmooth, methods"	NA	"grid, MASS, knitr, r2d2"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"gridBase"	"gridBase"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4-7"	NA	"R (>= 2.3.0)"	"graphics, grid"	NA	"lattice"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"gridExtra"	"gridExtra"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3"	NA	NA	"gtable, grid, grDevices, graphics, utils"	NA	"ggplot2, egg, lattice, knitr, testthat"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"gstat"	"gstat"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0-9"	NA	"R (>= 2.10)"	"utils, stats, graphics, methods, lattice, sp (>= 0.9-72), zoo,
-spacetime (>= 1.0-0), FNN"	NA	"fields, maps, mapdata, maptools, rgdal (>= 0.5.2), rgeos, sf
-(>= 0.7-2), stars (>= 0.3-0), xts, raster, future, future.apply"	NA	"GPL (>= 2.0)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"gtable"	"gtable"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.0"	NA	"R (>= 3.0)"	"grid"	NA	"covr, testthat, knitr, rmarkdown, ggplot2, profvis"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"gtools"	"gtools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.9.2"	NA	"methods, stats, utils"	NA	NA	"car, gplots, knitr, rstudioapi, SGP, taxize"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"hash"	"hash"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2.6.2"	NA	"R (>= 2.12.0), methods, utils"	NA	NA	"testthat"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"highr"	"highr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9"	NA	"R (>= 3.2.3)"	"xfun (>= 0.18)"	NA	"knitr, markdown, testit"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"Hmisc"	"Hmisc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.7-0"	NA	"lattice, survival (>= 3.1-6), Formula, ggplot2 (>= 2.2)"	"methods, latticeExtra, cluster, rpart, nnet, foreign, gtable,
-grid, gridExtra, data.table, htmlTable (>= 1.11.0), viridis,
-htmltools, base64enc"	NA	"acepack, chron, rms, mice, tables, knitr, plotly (>= 4.5.6),
-rlang, plyr, VGAM"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"hms"	"hms"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.1"	NA	NA	"ellipsis (>= 0.3.2), lifecycle, methods, pkgconfig, rlang,
-vctrs (>= 0.3.8)"	NA	"crayon, lubridate, pillar (>= 1.1.0), testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"htmlTable"	"htmlTable"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.4.0"	NA	NA	"stringr, knitr (>= 1.6), magrittr (>= 1.5), methods,
+testthat (>= 3.0.0), vctrs (>= 0.3.0), waldo (>= 0.3.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"gplots"	"gplots"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1.3"	NA	"R (>= 3.0)"	"gtools, stats, caTools, KernSmooth, methods"	NA	"grid, MASS, knitr, r2d2"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"gridBase"	"gridBase"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4-7"	NA	"R (>= 2.3.0)"	"graphics, grid"	NA	"lattice"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"gridExtra"	"gridExtra"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3"	NA	NA	"gtable, grid, grDevices, graphics, utils"	NA	"ggplot2, egg, lattice, knitr, testthat"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"gstat"	"gstat"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1-1"	NA	"R (>= 2.10)"	"utils, stats, graphics, methods, lattice, sp (>= 0.9-72), zoo,
+sf (>= 0.7-2), sftime, spacetime (>= 1.2-8), stars, FNN"	NA	"fields, maps, mapdata, xts, raster, future, future.apply"	NA	"GPL (>= 2.0)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"gtable"	"gtable"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.3"	NA	"R (>= 3.5)"	"cli, glue, grid, lifecycle, rlang (>= 1.1.0)"	NA	"covr, ggplot2, knitr, profvis, rmarkdown, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"gtools"	"gtools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.9.4"	NA	"methods, stats, utils"	NA	NA	"car, gplots, knitr, rstudioapi, SGP, taxize"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"hash"	"hash"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.2.6.2"	NA	"R (>= 2.12.0), methods, utils"	NA	NA	"testthat"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"haven"	"haven"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.5.3"	NA	"R (>= 3.6)"	"cli (>= 3.0.0), forcats (>= 0.2.0), hms, lifecycle, methods,
+readr (>= 0.1.0), rlang (>= 0.4.0), tibble, tidyselect, vctrs
+(>= 0.3.0)"	"cpp11"	"covr, crayon, fs, knitr, pillar (>= 1.4.0), rmarkdown,
+testthat (>= 3.0.0), utf8"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"highr"	"highr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.10"	NA	"R (>= 3.3.0)"	"xfun (>= 0.18)"	NA	"knitr, markdown, testit"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"Hmisc"	"Hmisc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"5.1-0"	NA	NA	"methods, ggplot2, cluster, rpart, nnet, foreign, gtable, grid,
+gridExtra, data.table, htmlTable (>= 1.11.0), viridis,
+htmltools, base64enc, colorspace, rmarkdown, knitr, Formula"	NA	"survival, qreport, acepack, chron, rms, mice, rstudioapi,
+tables, plotly (>= 4.5.6), rlang, plyr, VGAM, leaps, pcaPP,
+digest, parallel, polspline, abind, kableExtra, rio, lattice,
+latticeExtra, gt, sparkline, jsonlite, htmlwidgets"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"hms"	"hms"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.3"	NA	NA	"lifecycle, methods, pkgconfig, rlang (>= 1.0.2), vctrs (>=
+0.3.8)"	NA	"crayon, lubridate, pillar (>= 1.1.0), testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"htmlTable"	"htmlTable"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.4.1"	NA	NA	"stringr, knitr (>= 1.6), magrittr (>= 1.5), methods,
 checkmate, htmlwidgets, htmltools, rstudioapi (>= 0.6)"	NA	"testthat, XML, xml2, Hmisc, reshape, rmarkdown, chron,
 lubridate, tibble, purrr, tidyselect, glue, rlang, tidyr (>=
-0.7.2), dplyr (>= 0.7.4)"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"htmltools"	"htmltools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5.2"	NA	"R (>= 2.14.1)"	"utils, digest, grDevices, base64enc, rlang (>= 0.4.10),
-fastmap"	NA	"markdown, testthat, withr, Cairo, ragg, shiny"	"knitr"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"htmlwidgets"	"htmlwidgets"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.4"	NA	NA	"grDevices, htmltools (>= 0.3), jsonlite (>= 0.9.16), yaml"	NA	"knitr (>= 1.8), rmarkdown, testthat"	"shiny (>= 1.1)"	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"httpcode"	"httpcode"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.0"	NA	NA	NA	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"httpuv"	"httpuv"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.6.5"	NA	"R (>= 2.15.1)"	"Rcpp (>= 1.0.7), utils, R6, promises, later (>= 0.8.0)"	"Rcpp, later"	"testthat, callr, curl, websocket"	NA	"GPL (>= 2) | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"httr"	"httr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.3"	NA	"R (>= 3.2)"	"curl (>= 3.0.0), jsonlite, mime, openssl (>= 0.8), R6"	NA	"covr, httpuv, jpeg, knitr, png, readr, rmarkdown, testthat
-(>= 0.8.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"hunspell"	"hunspell"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.0.1"	NA	"R (>= 3.0.2)"	"Rcpp, digest"	"Rcpp (>= 0.12.12)"	"spelling, testthat, pdftools, janeaustenr, wordcloud2, knitr,
-stopwords, rmarkdown"	NA	"GPL-2 | LGPL-2.1 | MPL-1.1"	NA	NA	NA	NA	"yes"	"4.2.0"
-"igraph"	"igraph"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.1"	NA	"methods"	"graphics, grDevices, magrittr, Matrix, pkgconfig (>= 2.0.0),
-stats, utils"	NA	"ape, graph, igraphdata, rgl, scales, stats4, tcltk, testthat,
-withr, digest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ini"	"ini"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.1"	NA	NA	NA	NA	"testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"inline"	"inline"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.19"	NA	NA	"methods"	NA	"Rcpp (>= 0.11.0), tinytest"	NA	"LGPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"inlinedocs"	"inlinedocs"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2019.12.5"	NA	"methods, utils, R (>= 2.9)"	NA	NA	"future.apply, future"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"intamap"	"intamap"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4-16"	NA	"R (>= 2.14.0), sp (>= 0.9-0)"	"gstat (>= 0.9-36), automap, MBA, mvtnorm, MASS, evd,
-doParallel, foreach, rgdal, parallel, stats, methods,
-grDevices, utils, graphics"	NA	NA	"psgp"	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"intervals"	"intervals"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.15.2"	NA	"R (>= 2.9.0)"	"utils, graphics, methods"	NA	NA	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"isoband"	"isoband"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.5"	NA	NA	"grid, utils"	NA	"covr, ggplot2, knitr, magick, microbenchmark, rmarkdown, sf,
-testthat, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"iterators"	"iterators"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.14"	NA	"R (>= 2.5.0), utils"	NA	NA	"RUnit, foreach"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"no"	"4.2.0"
-"jagsUI"	"jagsUI"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.2"	NA	"R (>= 2.14.0),"	"rjags (>= 3-13), coda (>= 0.13), parallel, stats, grDevices,
-graphics, utils"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"jpeg"	"jpeg"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1-9"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"jquerylib"	"jquerylib"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.4"	NA	NA	"htmltools"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"jsonlite"	"jsonlite"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.0"	NA	"methods"	NA	NA	"httr, curl, vctrs, testthat, knitr, rmarkdown, R.rsp, sf"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"kernlab"	"kernlab"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9-30"	NA	"R (>= 2.10)"	"methods, stats, grDevices, graphics"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"knitr"	"knitr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.39"	NA	"R (>= 3.3.0)"	"evaluate (>= 0.15), highr, methods, stringr (>= 0.6), yaml (>=
-2.1.19), xfun (>= 0.29), tools"	NA	"markdown, formatR, testit, digest, rgl (>= 0.95.1201),
-codetools, rmarkdown, htmlwidgets (>= 0.7), webshot, tikzDevice
-(>= 0.10), tinytex, reticulate (>= 1.4), JuliaCall (>= 0.11.1),
-magick, png, jpeg, gifski, xml2 (>= 1.2.0), httr, DBI (>=
-0.4-1), showtext, tibble, sass, bslib, ragg, styler (>= 1.2.0),
-targets (>= 0.6.0)"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"ks"	"ks"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.13.5"	NA	"R (>= 2.10.0)"	"FNN (>= 1.1), kernlab, KernSmooth (>= 2.22), Matrix, mclust,
-mgcv, multicool, mvtnorm (>= 1.0-0), plot3D, pracma"	NA	"geometry, MASS, misc3d (>= 0.4-0), oz, rgl (>= 0.66)"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"labeling"	"labeling"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.2"	NA	NA	"stats, graphics"	NA	NA	NA	"MIT + file LICENSE | Unlimited"	NA	NA	NA	NA	"no"	"4.2.0"
-"lars"	"lars"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3"	NA	"R (>= 2.10)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"later"	"later"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.0"	NA	NA	"Rcpp (>= 0.12.9), rlang"	"Rcpp"	"knitr, rmarkdown, testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"latticeExtra"	"latticeExtra"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6-29"	NA	"R (>= 3.6.0), lattice"	"grid, stats, utils, grDevices, png, jpeg, RColorBrewer"	NA	"maps, mapproj, deldir, tripack, quantreg, zoo, MASS, mgcv"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"lavaan"	"lavaan"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6-11"	NA	"R(>= 3.4)"	"methods, stats4, stats, utils, graphics, MASS, mnormt,
-pbivnorm, numDeriv"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"lazyeval"	"lazyeval"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.2"	NA	"R (>= 3.1.0)"	NA	NA	"knitr, rmarkdown (>= 0.2.65), testthat, covr"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"leafem"	"leafem"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.0"	NA	"R (>= 3.1.0)"	"base64enc, geojsonsf, htmltools (>= 0.3), htmlwidgets, leaflet
-(>= 2.0.1), methods, raster, sf, png"	NA	"clipr, leafgl, mapdeck, plainview, rgdal, stars"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"leaflet"	"leaflet"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.1"	NA	"R (>= 3.1.0)"	"base64enc, crosstalk, htmlwidgets (>= 1.5.4), htmltools,
+0.7.2), dplyr (>= 0.7.4)"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"htmltools"	"htmltools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.5"	NA	"R (>= 2.14.1)"	"utils, digest, grDevices, base64enc, rlang (>= 0.4.10),
+fastmap (>= 1.1.0), ellipsis"	NA	"markdown, testthat, withr, Cairo, ragg, shiny"	"knitr"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"htmlwidgets"	"htmlwidgets"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6.2"	NA	NA	"grDevices, htmltools (>= 0.5.4), jsonlite (>= 0.9.16), yaml,
+knitr (>= 1.8), rmarkdown"	NA	"testthat"	"shiny (>= 1.1)"	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"httpcode"	"httpcode"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.0"	NA	NA	NA	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"httpuv"	"httpuv"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6.11"	NA	"R (>= 2.15.1)"	"Rcpp (>= 1.0.7), utils, R6, promises, later (>= 0.8.0)"	"Rcpp, later"	"testthat, callr, curl, websocket"	NA	"GPL (>= 2) | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"httr"	"httr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.6"	NA	"R (>= 3.5)"	"curl (>= 3.0.0), jsonlite, mime, openssl (>= 0.8), R6"	NA	"covr, httpuv, jpeg, knitr, png, readr, rmarkdown, testthat
+(>= 0.8.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"httr2"	"httr2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.3"	NA	"R (>= 3.4)"	"cli (>= 3.0.0), curl, glue, magrittr, openssl, R6, rappdirs,
+rlang (>= 1.0.0), withr"	NA	"askpass, bench, clipr, covr, docopt, httpuv, jose, jsonlite,
+knitr, purrr, rmarkdown, testthat (>= 3.0.0), tibble, webfakes,
+xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"hunspell"	"hunspell"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.0.2"	NA	"R (>= 3.0.2)"	"Rcpp, digest"	"Rcpp (>= 0.12.12)"	"spelling, testthat, pdftools, janeaustenr, wordcloud2, knitr,
+stopwords, rmarkdown"	NA	"GPL-2 | LGPL-2.1 | MPL-1.1"	NA	NA	NA	NA	"yes"	"4.2.3"
+"igraph"	"igraph"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.0.1"	NA	"methods, R (>= 3.5.0)"	"cli, graphics, grDevices, magrittr, Matrix, pkgconfig (>=
+2.0.0), rlang, stats, utils"	"cpp11 (>= 0.2.0)"	"ape (>= 5.7-0.1), callr, decor, digest, graph, igraphdata,
+knitr, rgl, rmarkdown, scales, stats4, tcltk, testthat, vdiffr,
+withr"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ini"	"ini"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.1"	NA	NA	NA	NA	"testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"inline"	"inline"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.19"	NA	NA	"methods"	NA	"Rcpp (>= 0.11.0), tinytest"	NA	"LGPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"inlinedocs"	"inlinedocs"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2019.12.5"	NA	"methods, utils, R (>= 2.9)"	NA	NA	"future.apply, future"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"intamap"	"intamap"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5-6"	NA	"R (>= 2.14.0), sp (>= 0.9-0)"	"gstat (>= 0.9-36), sf, automap, MBA, mvtnorm, MASS, evd,
+doParallel, foreach, parallel, stats, methods, grDevices,
+utils, graphics"	NA	"psgp, rgdal"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"interp"	"interp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-4"	NA	"R (>= 3.5.0)"	"Rcpp (>= 0.12.9), deldir"	"Rcpp, RcppEigen"	"sp, Deriv, Ryacas, ggplot2, gridExtra, lattice, stringi,
+stringr, scatterplot3d, MASS"	"RcppEigen"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"intervals"	"intervals"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.15.4"	NA	"R (>= 2.9.0)"	"utils, graphics, methods"	NA	NA	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.3"
+"isoband"	"isoband"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.7"	NA	NA	"grid, utils"	NA	"covr, ggplot2, knitr, magick, microbenchmark, rmarkdown, sf,
+testthat, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"iterators"	"iterators"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.14"	NA	"R (>= 2.5.0), utils"	NA	NA	"RUnit, foreach"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"no"	"4.2.3"
+"jagsUI"	"jagsUI"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.2"	NA	"R (>= 2.14.0),"	"rjags (>= 3-13), coda (>= 0.13), parallel, stats, grDevices,
+graphics, utils"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"jomo"	"jomo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.7-6"	NA	NA	"stats, lme4, survival, MASS, ordinal, tibble"	NA	"mitml"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"jpeg"	"jpeg"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-10"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"jquerylib"	"jquerylib"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.4"	NA	NA	"htmltools"	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"jsonlite"	"jsonlite"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8.7"	NA	"methods"	NA	NA	"httr, vctrs, testthat, knitr, rmarkdown, R.rsp, sf"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"kableExtra"	"kableExtra"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.4"	NA	"R (>= 3.1.0)"	"knitr (>= 1.16), magrittr, stringr (>= 1.0), xml2 (>= 1.1.1),
+rvest, rmarkdown (>= 1.6.0), scales, viridisLite, stats,
+grDevices, htmltools, rstudioapi, glue, tools, webshot, digest,
+graphics, svglite"	NA	"testthat, magick, formattable, sparkline"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"kernlab"	"kernlab"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9-32"	NA	"R (>= 2.10)"	"methods, stats, grDevices, graphics"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"knitr"	"knitr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.43"	NA	"R (>= 3.3.0)"	"evaluate (>= 0.15), highr, methods, tools, xfun (>= 0.39),
+yaml (>= 2.1.19)"	NA	"bslib, codetools, DBI (>= 0.4-1), digest, formatR, gifski,
+gridSVG, htmlwidgets (>= 0.7), curl, jpeg, JuliaCall (>=
+0.11.1), magick, markdown (>= 1.3), png, ragg, reticulate (>=
+1.4), rgl (>= 0.95.1201), rlang, rmarkdown, sass, showtext,
+styler (>= 1.2.0), targets (>= 0.6.0), testit, tibble,
+tikzDevice (>= 0.10), tinytex, webshot, rstudioapi, xml2 (>=
+1.2.0)"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"ks"	"ks"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.14.0"	NA	"R (>= 2.10.0)"	"FNN (>= 1.1), kernlab, KernSmooth (>= 2.22), Matrix, mclust,
+mgcv, multicool, mvtnorm (>= 1.0-0), plot3D, pracma"	NA	"geometry, MASS, misc3d (>= 0.4-0), oz, rgl (>= 0.66)"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"labeling"	"labeling"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.2"	NA	NA	"stats, graphics"	NA	NA	NA	"MIT + file LICENSE | Unlimited"	NA	NA	NA	NA	"no"	"4.2.0"
+"lars"	"lars"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3"	NA	"R (>= 2.10)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
+"later"	"later"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.1"	NA	NA	"Rcpp (>= 0.12.9), rlang"	"Rcpp"	"knitr, rmarkdown, testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"latticeExtra"	"latticeExtra"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6-30"	NA	"R (>= 3.6.0), lattice"	"grid, stats, utils, grDevices, png, jpeg, RColorBrewer,
+interp, MASS"	NA	"maps, mapproj, deldir, quantreg, zoo, mgcv"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"lavaan"	"lavaan"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6-16"	NA	"R(>= 3.4)"	"methods, stats4, stats, utils, graphics, MASS, mnormt,
+pbivnorm, numDeriv, quadprog"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"lazyeval"	"lazyeval"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.2"	NA	"R (>= 3.1.0)"	NA	NA	"knitr, rmarkdown (>= 0.2.65), testthat, covr"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"leafem"	"leafem"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.0"	NA	"R (>= 3.1.0)"	"base64enc, geojsonsf, htmltools (>= 0.3), htmlwidgets, leaflet
+(>= 2.0.1), methods, raster, sf, png"	NA	"clipr, leafgl, mapdeck, plainview, rgdal, stars"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"leaflet"	"leaflet"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.2"	NA	"R (>= 3.1.0)"	"base64enc, crosstalk, htmlwidgets (>= 1.5.4), htmltools,
 magrittr, markdown, methods, png, RColorBrewer, raster, scales
 (>= 1.0.0), sp, stats, viridis (>= 0.5.1), leaflet.providers
 (>= 1.8.0)"	NA	"knitr, maps, sf (>= 0.9-6), shiny, rgdal, rgeos, R6, RJSONIO,
-purrr, testthat (>= 3.0.0), s2"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"leaflet.providers"	"leaflet.providers"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.9.0"	NA	"R (>= 2.10)"	NA	NA	"V8, jsonlite, testthat (>= 2.1.0)"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"leafpop"	"leafpop"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.0"	NA	NA	"base64enc, brew, htmltools, htmlwidgets, sf, svglite, uuid"	NA	"lattice, leaflet (>= 2.0.0), sp"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"leaps"	"leaps"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1"	NA	""	NA	NA	"biglm"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"lifecycle"	"lifecycle"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.1"	NA	"R (>= 3.3)"	"glue, rlang (>= 0.4.10)"	NA	"covr, crayon, lintr, tidyverse, knitr, rmarkdown, testthat
-(>= 3.0.1), tools, tibble, vctrs"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"listenv"	"listenv"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8.0"	NA	"R (>= 3.1.2)"	NA	NA	"R.utils, R.rsp, markdown"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"lme4"	"lme4"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-29"	NA	"R (>= 3.2.0), Matrix (>= 1.2-1), methods, stats"	"graphics, grid, splines, utils, parallel, MASS, lattice, boot,
-nlme (>= 3.1-123), minqa (>= 1.1.15), nloptr (>= 1.0.4)"	"Rcpp (>= 0.10.5), RcppEigen"	"knitr, rmarkdown, PKPDmodels, MEMSS, testthat (>= 0.8.1),
-ggplot2, mlmRev, optimx (>= 2013.8.6), gamm4, pbkrtest, HSAUR3,
-numDeriv, car, dfoptim, mgcv, statmod, rr2, semEff, tibble"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"lmerTest"	"lmerTest"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1-3"	NA	"R (>= 3.2.5), lme4 (>= 1.1-10), stats, methods"	"numDeriv, MASS, ggplot2"	NA	"pbkrtest (>= 0.4-3), tools"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"lmtest"	"lmtest"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9-40"	NA	"R (>= 3.0.0), stats, zoo"	"graphics"	NA	"car, strucchange, sandwich, dynlm, stats4, survival, AER"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"logcondens"	"logcondens"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.6"	NA	"R (>= 2.10)"	"ks, graphics, stats"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"loo"	"loo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.5.1"	NA	"R (>= 3.1.2)"	"checkmate, matrixStats (>= 0.52), parallel, stats"	NA	"bayesplot (>= 1.7.0), brms (>= 2.10.0), ggplot2, graphics,
-knitr, rmarkdown, rstan, rstanarm (>= 2.19.0), rstantools,
-spdep, testthat (>= 2.1.0)"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"lubridate"	"lubridate"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.0"	NA	"methods, R (>= 3.2)"	"generics"	"cpp11 (>= 0.2.7)"	"covr, knitr, testthat (>= 2.1.0), vctrs (>= 0.3.0), rmarkdown"	"chron, timeDate, tis, zoo"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"lwgeom"	"lwgeom"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2-8"	NA	"R (>= 3.3.0)"	"Rcpp, units, sf (>= 0.9-3)"	"Rcpp, sf (>= 0.6-0)"	"covr, sp, geosphere, testthat"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"magrittr"	"magrittr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.3"	NA	"R (>= 3.4.0)"	NA	NA	"covr, knitr, rlang, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mapdata"	"mapdata"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3.0"	NA	"R (>= 2.14.0), maps (>= 2.0-7)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mapproj"	"mapproj"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.8"	NA	"R (>= 3.0.0), maps (>= 2.3-0)"	"stats, graphics"	NA	NA	NA	"Lucent Public License"	NA	NA	NA	NA	"yes"	"4.2.0"
-"maps"	"maps"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.4.0"	NA	"R (>= 3.5.0)"	"graphics, utils"	NA	"mapproj (>= 1.2-0), mapdata (>= 2.3.0), sp, rnaturalearth"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"maptools"	"maptools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-4"	NA	"R (>= 2.10), sp (>= 1.0-11)"	"foreign (>= 0.8), methods, grid, lattice, stats, utils,
+purrr, testthat (>= 3.0.0), s2"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"leaflet.providers"	"leaflet.providers"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.0"	NA	"R (>= 2.10)"	NA	NA	"V8, jsonlite, testthat (>= 2.1.0)"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"leafpop"	"leafpop"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.0"	NA	NA	"base64enc, brew, htmltools, htmlwidgets, sf, svglite, uuid"	NA	"lattice, leaflet (>= 2.0.0), sp"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"leaps"	"leaps"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1"	NA	""	NA	NA	"biglm"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"lifecycle"	"lifecycle"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.3"	NA	"R (>= 3.4)"	"cli (>= 3.4.0), glue, rlang (>= 1.0.6)"	NA	"covr, crayon, knitr, lintr, rmarkdown, testthat (>= 3.0.1),
+tibble, tidyverse, tools, vctrs, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"listenv"	"listenv"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9.0"	NA	"R (>= 3.1.2)"	NA	NA	"R.utils, R.rsp, markdown"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"lme4"	"lme4"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-34"	NA	"R (>= 3.5.0), Matrix (>= 1.2-1), methods, stats"	"graphics, grid, splines, utils, parallel, MASS, lattice, boot,
+nlme (>= 3.1-123), minqa (>= 1.1.15), nloptr (>= 1.0.4)"	"Rcpp (>= 0.10.5), RcppEigen"	"knitr, rmarkdown, MEMSS, testthat (>= 0.8.1), ggplot2,
+mlmRev, optimx (>= 2013.8.6), gamm4, pbkrtest, HSAUR3,
+numDeriv, car, dfoptim, mgcv, statmod, rr2, semEff, tibble,
+merDeriv"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"lmerTest"	"lmerTest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1-3"	NA	"R (>= 3.2.5), lme4 (>= 1.1-10), stats, methods"	"numDeriv, MASS, ggplot2"	NA	"pbkrtest (>= 0.4-3), tools"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"lmtest"	"lmtest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9-40"	NA	"R (>= 3.0.0), stats, zoo"	"graphics"	NA	"car, strucchange, sandwich, dynlm, stats4, survival, AER"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"logcondens"	"logcondens"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.7"	NA	"R (>= 2.10)"	"ks, graphics, stats"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"loo"	"loo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.6.0"	NA	"R (>= 3.1.2)"	"checkmate, matrixStats (>= 0.52), parallel, stats"	NA	"bayesplot (>= 1.7.0), brms (>= 2.10.0), ggplot2, graphics,
+knitr, posterior, rmarkdown, rstan, rstanarm (>= 2.19.0),
+rstantools, spdep, testthat (>= 2.1.0)"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"lubridate"	"lubridate"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.2"	NA	"methods, R (>= 3.2)"	"generics, timechange (>= 0.1.1)"	NA	"covr, knitr, rmarkdown, testthat (>= 2.1.0), vctrs (>= 0.5.0)"	"chron, data.table, timeDate, tis, zoo"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"lwgeom"	"lwgeom"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2-13"	NA	"R (>= 3.3.0)"	"Rcpp, units, sf (>= 0.9-3)"	"Rcpp, sf (>= 0.6-0)"	"covr, sp, geosphere, testthat"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"magrittr"	"magrittr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.3"	NA	"R (>= 3.4.0)"	NA	NA	"covr, knitr, rlang, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"mapdata"	"mapdata"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.1"	NA	"R (>= 2.14.0), maps (>= 2.0-7)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"mapproj"	"mapproj"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.11"	NA	"R (>= 3.0.0), maps (>= 2.3-0)"	"stats, graphics"	NA	NA	NA	"Lucent Public License"	NA	NA	NA	NA	"yes"	"4.2.3"
+"maps"	"maps"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.4.1"	NA	"R (>= 3.5.0)"	"graphics, utils"	NA	"mapproj (>= 1.2-0), mapdata (>= 2.3.0), sp, rnaturalearth"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"maptools"	"maptools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-8"	NA	"R (>= 2.10), sp (>= 1.0-11)"	"foreign (>= 0.8), methods, grid, lattice, stats, utils,
 grDevices"	NA	"rgeos (>= 0.1-8), spatstat.geom (>= 1.65-0), PBSmapping,
 maps, RColorBrewer, raster, polyclip, plotrix, spatstat.linnet
-(>= 1.65-3), spatstat.utils (>= 1.19.0), spatstat (>= 2.0-0)"	"gpclib"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mapview"	"mapview"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.11.0"	NA	"methods, R (>= 3.6.0)"	"base64enc, htmltools, htmlwidgets, lattice, leafem, leaflet
+(>= 1.65-3), spatstat.utils (>= 1.19.0), spatstat (>= 2.0-0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"mapview"	"mapview"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.11.0"	NA	"methods, R (>= 3.6.0)"	"base64enc, htmltools, htmlwidgets, lattice, leafem, leaflet
 (>= 2.0.0), leafpop, png, raster, satellite, scales (>= 0.2.5),
 servr, sf, sp, webshot"	NA	"covr, knitr, later, leaflet.extras2, leafsync, lwgeom,
 mapdeck, plainview, poorman, rgdal, rmarkdown, rstudioapi, s2,
-stars, tinytest"	NA	"GPL (>= 3) | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"markdown"	"markdown"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1"	NA	"R (>= 2.11.1)"	"utils, xfun, mime (>= 0.3)"	NA	"knitr, RCurl"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"MatrixModels"	"MatrixModels"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5-0"	NA	"R (>= 3.0.1)"	"stats, methods, Matrix (>= 1.1-5)"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"matrixStats"	"matrixStats"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.62.0"	NA	"R (>= 2.12.0)"	NA	NA	"base64enc, ggplot2, knitr, markdown, microbenchmark,
-R.devices, R.rsp"	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"maxlike"	"maxlike"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1-8"	NA	"R (>= 2.10.0), raster"	NA	NA	"dismo"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"MBA"	"MBA"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.0-9"	NA	"R (> 2.10.0)"	NA	"BH"	"sp"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mclust"	"mclust"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"5.4.9"	NA	"R (>= 3.0)"	"stats, utils, graphics, grDevices"	NA	"knitr (>= 1.12), rmarkdown (>= 0.9), mix (>= 1.0), geometry
-(>= 0.3-6), MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"memoise"	"memoise"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.1"	NA	NA	"rlang (>= 0.4.10), cachem"	NA	"digest, aws.s3, covr, googleAuthR, googleCloudStorageR, httr,
-testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"mice"	"mice"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.14.0"	NA	"R (>= 2.10.0)"	"broom, dplyr, generics, graphics, grDevices, lattice, methods,
-Rcpp, rlang, stats, tidyr, utils, withr"	"cpp11, Rcpp"	"broom.mixed, decor, glmnet, haven, knitr, lme4, lmtest, MASS,
-metafor, mitml, miceadds, nnet, pan, randomForest, ranger,
-rmarkdown, rpart, survival, testthat"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"microbenchmark"	"microbenchmark"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.9"	NA	NA	"graphics, stats"	NA	"ggplot2, multcomp, RUnit"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mime"	"mime"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.12"	NA	NA	"tools"	NA	NA	NA	"GPL"	NA	NA	NA	NA	"yes"	"4.2.0"
-"minqa"	"minqa"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.4"	NA	NA	"Rcpp (>= 0.9.10)"	"Rcpp"	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"misc3d"	"misc3d"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9-1"	NA	NA	"grDevices, graphics, stats, tcltk"	NA	"rgl, tkrplot, MASS"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"mnormt"	"mnormt"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.2"	NA	"R (>= 2.2.0)"	"tmvnsim (>= 1.0-2)"	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"modeltools"	"modeltools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2-23"	NA	"stats, stats4"	"methods"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"MPV"	"MPV"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.57"	NA	"R (>= 2.0.1), lattice, KernSmooth"	NA	NA	NA	NA	"Unlimited"	NA	NA	NA	NA	"no"	"4.2.0"
-"multcomp"	"multcomp"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4-19"	NA	"stats, graphics, mvtnorm (>= 1.0-10), survival (>= 2.39-4),
+stars, tinytest"	NA	"GPL (>= 3) | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"markdown"	"markdown"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7"	NA	"R (>= 2.11.1)"	"utils, commonmark (>= 1.9.0), xfun (>= 0.38)"	NA	"knitr, rmarkdown (>= 2.18), yaml, RCurl"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"Matrix"	"Matrix"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6-0"	"recommended"	"R (>= 3.5.0), methods"	"grDevices, graphics, grid, lattice, stats, utils"	NA	"MASS, datasets, sfsmisc"	"SparseM, graph"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"MatrixModels"	"MatrixModels"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5-2"	NA	"R (>= 3.6.0)"	"stats, methods, Matrix (>= 1.6-0)"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"matrixStats"	"matrixStats"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R (>= 2.12.0)"	NA	NA	"base64enc, ggplot2, knitr, markdown, microbenchmark,
+R.devices, R.rsp"	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.3"
+"maxlike"	"maxlike"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-9"	NA	"R (>= 2.10.0), raster"	NA	NA	"dismo"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"MBA"	"MBA"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-0"	NA	"R (> 2.10.0)"	NA	"BH"	"sp"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"mclust"	"mclust"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"6.0.0"	NA	"R (>= 3.0)"	"stats, utils, graphics, grDevices"	NA	"knitr (>= 1.12), rmarkdown (>= 0.9), mix (>= 1.0), geometry
+(>= 0.3-6), MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"memoise"	"memoise"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.1"	NA	NA	"rlang (>= 0.4.10), cachem"	NA	"digest, aws.s3, covr, googleAuthR, googleCloudStorageR, httr,
+testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"mice"	"mice"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.16.0"	NA	"R (>= 2.10.0)"	"broom, dplyr, generics, glmnet, graphics, grDevices, lattice,
+methods, mitml, nnet, Rcpp, rpart, rlang, stats, tidyr, utils"	"cpp11, Rcpp"	"broom.mixed, future, furrr, haven, knitr, lme4, MASS,
+miceadds, pan, parallelly, purrr, ranger, randomForest,
+rmarkdown, rstan, survival, testthat"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"microbenchmark"	"microbenchmark"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.10"	NA	NA	"graphics, stats"	NA	"ggplot2, multcomp, RUnit"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"mime"	"mime"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.12"	NA	NA	"tools"	NA	NA	NA	"GPL"	NA	NA	NA	NA	"yes"	"4.2.0"
+"miniUI"	"miniUI"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.1.1"	NA	NA	"shiny (>= 0.13), htmltools (>= 0.3), utils"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"minqa"	"minqa"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.5"	NA	NA	"Rcpp (>= 0.9.10)"	"Rcpp"	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"misc3d"	"misc3d"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9-1"	NA	NA	"grDevices, graphics, stats, tcltk"	NA	"rgl, tkrplot, MASS"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"mitml"	"mitml"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4-5"	NA	NA	"pan, jomo, haven, grDevices, graphics, stats, methods, utils"	NA	"mice, miceadds, Amelia, lme4, nlme, lavaan, geepack, glmmTMB,
+survival, knitr, rmarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"mnormt"	"mnormt"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.1"	NA	"R (>= 2.2.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.1"
+"modeltools"	"modeltools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2-23"	NA	"stats, stats4"	"methods"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
+"MPV"	"MPV"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.63"	NA	"R (>= 3.5.0), lattice, KernSmooth, randomForest"	NA	NA	NA	NA	"Unlimited"	NA	NA	NA	NA	"no"	"4.2.3"
+"multcomp"	"multcomp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4-25"	NA	"stats, graphics, mvtnorm (>= 1.0-10), survival (>= 2.39-4),
 TH.data (>= 1.0-2)"	"sandwich (>= 2.3-0), codetools"	NA	"lme4 (>= 0.999375-16), nlme, robustbase, coin, MASS, foreign,
 xtable, lmtest, coxme (>= 2.2-1), SimComp, ISwR, tram (>=
-0.2-5), fixest (>= 0.10)"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"multicool"	"multicool"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1-12"	NA	"methods, Rcpp (>= 0.11.2)"	NA	"Rcpp"	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"munsell"	"munsell"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5.0"	NA	NA	"colorspace, methods"	NA	"ggplot2, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"mvtnorm"	"mvtnorm"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-3"	NA	"R(>= 3.5.0)"	"stats, methods"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"nanotime"	"nanotime"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.6"	NA	NA	"methods, bit64, RcppCCTZ (>= 0.2.9), zoo"	"Rcpp, RcppCCTZ, RcppDate"	"tinytest, data.table, xts"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"natserv"	"natserv"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.0"	NA	"R(>= 3.2.1)"	"crul (>= 0.7.0), jsonlite, tibble"	NA	"testthat, knitr, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"ncdf4"	"ncdf4"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.19"	NA	NA	NA	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"nloptr"	"nloptr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.1"	NA	NA	NA	"testthat"	"knitr, rmarkdown, xml2, testthat (>= 3.0.0), covr"	NA	"LGPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"numDeriv"	"numDeriv"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2016.8-1.1"	NA	"R (>= 2.11.1)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"openssl"	"openssl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.1"	NA	NA	"askpass"	NA	"curl, testthat (>= 2.1.0), digest, knitr, rmarkdown,
-jsonlite, jose, sodium"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"openxlsx"	"openxlsx"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.2.5"	NA	"R (>= 3.3.0)"	"grDevices, methods, Rcpp, stats, stringi, utils, zip"	"Rcpp"	"knitr, rmarkdown, roxygen2, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ordinal"	"ordinal"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2019.12-10"	NA	"R (>= 2.13.0), stats, methods"	"ucminf, MASS, Matrix, numDeriv"	NA	"lme4, nnet, xtable, testthat (>= 0.8), tools"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"parallelly"	"parallelly"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.31.1"	NA	NA	"parallel, tools, utils"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"pbapply"	"pbapply"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-0"	NA	"R (>= 3.2.0)"	"parallel"	NA	"shiny"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"pbivnorm"	"pbivnorm"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6.0"	NA	NA	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"pbkrtest"	"pbkrtest"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5.1"	NA	"R (>= 3.5.0), lme4 (>= 1.1.10)"	"broom, dplyr, magrittr, MASS, Matrix (>= 1.2.3), methods,
-numDeriv, parallel, knitr"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"pcaPP"	"pcaPP"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0-1"	NA	NA	"mvtnorm, methods"	NA	"robustbase"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"phangorn"	"phangorn"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.8.1"	NA	"ape (>= 5.5), R (>= 4.1.0)"	"fastmatch, graphics, grDevices, igraph (>= 1.0), Matrix,
-methods, parallel, quadprog, Rcpp, stats, utils"	"Rcpp"	"Biostrings, knitr, magick, prettydoc, rgl, rmarkdown, seqinr,
-seqLogo, tinytest, xtable"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"pillar"	"pillar"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7.0"	NA	NA	"cli (>= 2.3.0), crayon (>= 1.3.4), ellipsis (>= 0.3.2), fansi,
-glue, lifecycle, rlang (>= 0.3.0), utf8 (>= 1.1.0), utils,
-vctrs (>= 0.3.8)"	NA	"bit64, debugme, DiagrammeR, dplyr, formattable, ggplot2,
+0.2-5), fixest (>= 0.10), glmmTMB"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"multicool"	"multicool"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-12"	NA	"methods, Rcpp (>= 0.11.2)"	NA	"Rcpp"	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"munsell"	"munsell"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.0"	NA	NA	"colorspace, methods"	NA	"ggplot2, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"mvtnorm"	"mvtnorm"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2-2"	NA	"R(>= 3.5.0)"	"stats"	NA	"qrng, numDeriv"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"nanotime"	"nanotime"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.7"	NA	NA	"methods, bit64, RcppCCTZ (>= 0.2.9), zoo"	"Rcpp, RcppCCTZ, RcppDate"	"tinytest, data.table, xts"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"natserv"	"natserv"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R(>= 3.2.1)"	"crul (>= 0.7.0), jsonlite, tibble"	NA	"testthat, knitr, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"ncdf4"	"ncdf4"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.21"	NA	NA	NA	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"nloptr"	"nloptr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.3"	NA	NA	NA	"testthat"	"knitr, rmarkdown, xml2, testthat (>= 3.0.0), covr"	NA	"LGPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"numDeriv"	"numDeriv"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2016.8-1.1"	NA	"R (>= 2.11.1)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
+"openssl"	"openssl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.0"	NA	NA	"askpass"	NA	"curl, testthat (>= 2.1.0), digest, knitr, rmarkdown,
+jsonlite, jose, sodium"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"openxlsx"	"openxlsx"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.2.5.2"	NA	"R (>= 3.3.0)"	"grDevices, methods, Rcpp, stats, stringi, utils, zip"	"Rcpp"	"knitr, rmarkdown, roxygen2, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ordinal"	"ordinal"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2022.11-16"	NA	"R (>= 2.13.0), stats, methods"	"ucminf, MASS, Matrix, numDeriv, nlme"	NA	"lme4, nnet, xtable, testthat (>= 0.8), tools"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"pan"	"pan"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8"	NA	NA	NA	NA	"mitools, lme4"	NA	"GPL-3"	NA	"no"	NA	NA	"yes"	"4.2.3"
+"parallelly"	"parallelly"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.36.0"	NA	NA	"parallel, tools, utils"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"pbapply"	"pbapply"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7-2"	NA	"R (>= 3.2.0)"	"parallel"	NA	"shiny, future, future.apply"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"pbivnorm"	"pbivnorm"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6.0"	NA	NA	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
+"pbkrtest"	"pbkrtest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.2"	NA	"R (>= 4.1.0), lme4 (>= 1.1.31)"	"broom, dplyr, MASS, Matrix (>= 1.2.3), methods, numDeriv,
+parallel"	NA	"knitr"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"pcaPP"	"pcaPP"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0-3"	NA	NA	"mvtnorm, methods"	NA	"robustbase"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"phangorn"	"phangorn"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.11.1"	NA	"ape (>= 5.6), R (>= 4.1.0)"	"digest, fastmatch, generics, graphics, grDevices, igraph (>=
+1.0), Matrix, methods, parallel, quadprog, Rcpp, stats, utils"	"Rcpp"	"Biostrings, knitr, magick, rgl, rmarkdown, seqinr, seqLogo,
+tinytest, xtable"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"pillar"	"pillar"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.0"	NA	NA	"cli (>= 2.3.0), fansi, glue, lifecycle, rlang (>= 1.0.2), utf8
+(>= 1.1.0), utils, vctrs (>= 0.5.0)"	NA	"bit64, DBI, debugme, DiagrammeR, dplyr, formattable, ggplot2,
 knitr, lubridate, nanotime, nycflights13, palmerpenguins,
 rmarkdown, scales, stringi, survival, testthat (>= 3.1.1),
-tibble, units (>= 0.7.2), vdiffr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"pkgbuild"	"pkgbuild"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.1"	NA	"R (>= 3.1)"	"callr (>= 3.2.0), cli, crayon, desc, prettyunits, R6,
-rprojroot, withr (>= 2.3.0)"	NA	"Rcpp, cpp11, testthat, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"pkgconfig"	"pkgconfig"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.3"	NA	NA	"utils"	NA	"covr, testthat, disposables (>= 1.0.3)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"pkgdown"	"pkgdown"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.3"	NA	"R (>= 3.1.0)"	"bslib (>= 0.3.1), callr (>= 2.0.2), crayon, desc, digest,
-downlit (>= 0.4.0), fs (>= 1.4.0), httr (>= 1.4.2), jsonlite,
-magrittr, memoise, purrr, ragg, rlang (>= 1.0.0), rmarkdown (>=
+tibble, units (>= 0.7.2), vdiffr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"pkgbuild"	"pkgbuild"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.2"	NA	"R (>= 3.4)"	"callr (>= 3.2.0), cli (>= 3.4.0), crayon, desc, prettyunits,
+processx, R6, rprojroot"	NA	"covr, cpp11, knitr, mockery, Rcpp, rmarkdown, testthat (>=
+3.0.0), withr (>= 2.3.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"pkgconfig"	"pkgconfig"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.3"	NA	NA	"utils"	NA	"covr, testthat, disposables (>= 1.0.3)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"pkgdown"	"pkgdown"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.7"	NA	"R (>= 3.1.0)"	"bslib (>= 0.3.1), callr (>= 3.7.3), cli, desc, digest, downlit
+(>= 0.4.0), fs (>= 1.4.0), httr (>= 1.4.2), jsonlite, magrittr,
+memoise, purrr, ragg, rlang (>= 1.0.0), rmarkdown (>=
 1.1.9007), tibble, whisker, withr (>= 2.4.3), xml2 (>= 1.3.1),
 yaml"	NA	"covr, diffviewer, evaluate, htmltools, htmlwidgets, knitr,
 lifecycle, methods, openssl, pkgload (>= 1.0.2), rsconnect,
-rstudioapi, rticles, sass, testthat (>= 3.1.3), tools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"pkgload"	"pkgload"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.4"	NA	NA	"cli, crayon, desc, methods, rlang, rprojroot, rstudioapi,
-utils, withr"	NA	"bitops, covr, pkgbuild, Rcpp, testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"plot3D"	"plot3D"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4"	NA	"R (>= 2.15)"	"misc3d, stats, graphics, grDevices, methods"	NA	NA	NA	"GPL (>= 3.0)"	NA	NA	NA	NA	"no"	"4.2.0"
-"plotly"	"plotly"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4.10.0"	NA	"R (>= 3.2.0), ggplot2 (>= 3.0.0)"	"tools, scales, httr (>= 1.3.0), jsonlite (>= 1.6), magrittr,
+rstudioapi, rticles, sass, testthat (>= 3.1.3), tools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"pkgload"	"pkgload"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.2.1"	NA	"R (>= 3.4.0)"	"cli (>= 3.3.0), crayon, desc, fs, glue, methods, rlang (>=
+1.0.3), rprojroot, utils, withr (>= 2.4.3)"	NA	"bitops, covr, mathjaxr, mockr, pak, pkgbuild, Rcpp, remotes,
+rstudioapi, testthat (>= 3.1.0)"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"plot3D"	"plot3D"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4"	NA	"R (>= 2.15)"	"misc3d, stats, graphics, grDevices, methods"	NA	NA	NA	"GPL (>= 3.0)"	NA	NA	NA	NA	"no"	"4.2.3"
+"plotly"	"plotly"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.10.2"	NA	"R (>= 3.2.0), ggplot2 (>= 3.0.0)"	"tools, scales, httr (>= 1.3.0), jsonlite (>= 1.6), magrittr,
 digest, viridisLite, base64enc, htmltools (>= 0.3.6),
 htmlwidgets (>= 1.5.2.9001), tidyr (>= 1.0.0), RColorBrewer,
 dplyr, vctrs, tibble, lazyeval (>= 0.2.0), rlang (>= 0.4.10),
-crosstalk, purrr, data.table, promises"	NA	"MASS, maps, hexbin, ggthemes, GGally, testthat, knitr,
-devtools, shiny (>= 1.1.0), shinytest (>= 1.3.0), curl,
-rmarkdown, Cairo, broom, webshot, listviewer, dendextend,
-maptools, rgeos, sf, png, IRdisplay, processx, plotlyGeoAssets,
-forcats, palmerpenguins, rversions, reticulate"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"plyr"	"plyr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.7"	NA	"R (>= 3.1.0)"	"Rcpp (>= 0.11.0)"	"Rcpp"	"abind, covr, doParallel, foreach, iterators, itertools,
-tcltk, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"png"	"png"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1-7"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"polspline"	"polspline"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.20"	NA	NA	"stats, graphics"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"polyclip"	"polyclip"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.10-0"	NA	"R (>= 3.0.0)"	NA	NA	NA	NA	"BSL"	NA	NA	NA	NA	"yes"	"4.2.0"
-"pracma"	"pracma"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3.8"	NA	"R (>= 3.1.0)"	"graphics, grDevices, stats, utils"	NA	"NlcOptim, quadprog"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"praise"	"praise"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.0"	NA	NA	NA	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"prettydoc"	"prettydoc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.1"	NA	NA	"rmarkdown (>= 1.17)"	NA	"knitr, KernSmooth"	NA	"Apache License (>= 2.0)"	NA	NA	NA	NA	"no"	"4.2.0"
-"prettyunits"	"prettyunits"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.1"	NA	NA	NA	NA	"codetools, covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"pROC"	"pROC"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.18.0"	NA	"R (>= 2.14)"	"methods, plyr, Rcpp (>= 0.11.1)"	"Rcpp"	"microbenchmark, tcltk, MASS, logcondens, doParallel,
-testthat, vdiffr, ggplot2"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"processx"	"processx"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.5.3"	NA	"R (>= 3.4.0)"	"ps (>= 1.2.0), R6, utils"	NA	"callr (>= 3.7.0), cli (>= 1.1.0), codetools, covr, curl,
-debugme, parallel, testthat (>= 3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"progress"	"progress"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.2"	NA	NA	"hms, prettyunits, R6, crayon"	NA	"Rcpp, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"promises"	"promises"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0.1"	NA	NA	"R6, Rcpp, later, rlang, stats, magrittr"	"later, Rcpp"	"testthat, future (>= 1.21.0), fastmap (>= 1.1.0), purrr,
-knitr, rmarkdown, vembedr, spelling"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"proxy"	"proxy"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4-26"	NA	"R (>= 3.4.0)"	"stats, utils"	NA	"cba"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ps"	"ps"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7.0"	NA	"R (>= 3.4)"	"utils"	NA	"callr, covr, curl, pingr, processx (>= 3.1.0), R6, rlang,
-testthat (>= 3.0.0), tibble"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"pscl"	"pscl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.5"	NA	NA	"MASS, datasets, grDevices, graphics, stats, utils"	NA	"lattice, MCMCpack, car, lmtest, sandwich, zoo, coda, vcd,
-mvtnorm, mgcv"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"purrr"	"purrr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.4"	NA	"R (>= 3.2)"	"magrittr (>= 1.5), rlang (>= 0.3.1)"	NA	"covr, crayon, dplyr (>= 0.7.8), knitr, rmarkdown, testthat,
-tibble, tidyselect"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"quadprog"	"quadprog"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-8"	NA	"R (>= 3.1.0)"	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"quantreg"	"quantreg"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"5.93"	NA	"R (>= 3.5), stats, SparseM"	"methods, graphics, Matrix, MatrixModels, survival, MASS"	NA	"tripack, akima, rgl, logspline, nor1mix, Formula, zoo, R.rsp,
-conquer"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"R.cache"	"R.cache"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.15.0"	NA	"R (>= 2.14.0)"	"utils, R.methodsS3 (>= 1.8.1), R.oo (>= 1.24.0), R.utils (>=
-2.10.1), digest (>= 0.6.13)"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R.devices"	"R.devices"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.17.0"	NA	"R (>= 2.14.0)"	"grDevices, R.methodsS3 (>= 1.8.1), R.oo (>= 1.24.0), R.utils
-(>= 2.10.1), base64enc (>= 0.1-2)"	NA	"digest (>= 0.6.13), Cairo (>= 1.5-9), R.rsp"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R.methodsS3"	"R.methodsS3"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.1"	NA	"R (>= 2.13.0)"	"utils"	NA	"codetools"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R.oo"	"R.oo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.24.0"	NA	"R (>= 2.13.0), R.methodsS3 (>= 1.8.0)"	"methods, utils"	NA	"tools"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R.rsp"	"R.rsp"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.44.0"	NA	"R (>= 2.14.0)"	"methods, stats, tools, utils, R.methodsS3 (>= 1.7.1), R.oo (>=
-1.23.0), R.utils, R.cache, digest (>= 0.6.13)"	NA	"tcltk, markdown (>= 0.8), knitr (>= 1.9), R.devices (>=
-2.16.1), base64enc (>= 0.1-2)"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R.utils"	"R.utils"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.11.0"	NA	"R (>= 2.14.0), R.oo (>= 1.24.0)"	"methods, utils, tools, R.methodsS3 (>= 1.8.1)"	NA	"digest (>= 0.6.10)"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R2jags"	"R2jags"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.7-1"	NA	"R (>= 2.14.0), rjags (>= 3-3)"	"abind, coda (>= 0.13), graphics, grDevices, methods,
-R2WinBUGS, parallel, stats, utils"	NA	"testthat (>= 3.0.0)"	NA	"GPL (> 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"R2OpenBUGS"	"R2OpenBUGS"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.2-3.2.1"	NA	"R (>= 2.13.0)"	"coda (>= 0.11-0), boot"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"R2WinBUGS"	"R2WinBUGS"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1-21"	NA	"R (>= 2.13.0), coda (>= 0.11-0), boot"	"utils, stats, graphics"	NA	"BRugs (>= 0.3-2)"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"R6"	"R6"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.5.1"	NA	"R (>= 3.0)"	NA	NA	"testthat, pryr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"ragg"	"ragg"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.2"	NA	NA	"systemfonts (>= 1.0.3), textshaping (>= 0.3.0)"	"systemfonts, textshaping"	"covr, testthat, grid, graphics"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"randomNames"	"randomNames"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-0.0"	NA	"R (>= 4.0)"	"crayon, data.table (>= 1.14.0), toOrdinal (>= 1.1)"	NA	"knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"RANN"	"RANN"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.6.1"	NA	NA	NA	NA	"testthat"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rappdirs"	"rappdirs"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.3"	NA	"R (>= 3.2)"	NA	NA	"roxygen2, testthat (>= 3.0.0), covr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"raster"	"raster"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.5-15"	NA	"sp (>= 1.4-5), R (>= 3.5.0)"	"Rcpp, methods, terra (>= 1.5-12)"	"Rcpp"	"rgdal (>= 1.5-23), rgeos (>= 0.5-3), ncdf4, igraph, tcltk,
-parallel, rasterVis, MASS, sf, tinytest, gstat, fields,
-exactextractr"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ratelimitr"	"ratelimitr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.1"	NA	NA	"assertthat"	NA	"testthat, microbenchmark, knitr, rmarkdown, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rcmdcheck"	"rcmdcheck"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.0"	NA	NA	"callr (>= 3.1.1.9000), cli (>= 3.0.0), curl, desc (>= 1.2.0),
+crosstalk, purrr, data.table, promises"	NA	"MASS, maps, hexbin, ggthemes, GGally, ggalluvial, testthat,
+knitr, shiny (>= 1.1.0), shinytest (>= 1.3.0), curl, rmarkdown,
+Cairo, broom, webshot, listviewer, dendextend, maptools, rgeos,
+sf, png, IRdisplay, processx, plotlyGeoAssets, forcats,
+palmerpenguins, rversions, reticulate, rsvg"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"plyr"	"plyr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8.8"	NA	"R (>= 3.1.0)"	"Rcpp (>= 0.11.0)"	"Rcpp"	"abind, covr, doParallel, foreach, iterators, itertools,
+tcltk, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"png"	"png"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1-8"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"polspline"	"polspline"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.23"	NA	NA	"stats, graphics"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"polyclip"	"polyclip"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.10-4"	NA	"R (>= 3.0.0)"	NA	NA	NA	NA	"BSL"	NA	NA	NA	NA	"yes"	"4.2.1"
+"pracma"	"pracma"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.4.2"	NA	"R (>= 3.1.0)"	"graphics, grDevices, stats, utils"	NA	"NlcOptim, quadprog"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"praise"	"praise"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	NA	NA	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"prettydoc"	"prettydoc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.1"	NA	NA	"rmarkdown (>= 1.17)"	NA	"knitr, KernSmooth"	NA	"Apache License (>= 2.0)"	NA	NA	NA	NA	"no"	"4.2.3"
+"prettyunits"	"prettyunits"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.1"	NA	NA	NA	NA	"codetools, covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"pROC"	"pROC"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.18.4"	NA	"R (>= 2.14)"	"methods, plyr, Rcpp (>= 0.11.1)"	"Rcpp"	"microbenchmark, tcltk, MASS, logcondens, doParallel,
+testthat, vdiffr, ggplot2, rlang"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"processx"	"processx"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.8.2"	NA	"R (>= 3.4.0)"	"ps (>= 1.2.0), R6, utils"	NA	"callr (>= 3.7.3), cli (>= 3.3.0), codetools, covr, curl,
+debugme, parallel, rlang (>= 1.0.2), testthat (>= 3.0.0),
+webfakes, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"profvis"	"profvis"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.8"	NA	"R (>= 3.0)"	"htmlwidgets (>= 0.3.2), purrr, rlang (>= 0.4.9), stringr,
+vctrs"	NA	"knitr, ggplot2, rmarkdown, testthat (>= 3.0.0), devtools,
+shiny, htmltools"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"progress"	"progress"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.2"	NA	NA	"hms, prettyunits, R6, crayon"	NA	"Rcpp, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"promises"	"promises"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.0.1"	NA	NA	"R6, Rcpp, later, rlang, stats, magrittr"	"later, Rcpp"	"testthat, future (>= 1.21.0), fastmap (>= 1.1.0), purrr,
+knitr, rmarkdown, vembedr, spelling"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"proxy"	"proxy"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4-27"	NA	"R (>= 3.4.0)"	"stats, utils"	NA	"cba"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ps"	"ps"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7.5"	NA	"R (>= 3.4)"	"utils"	NA	"callr, covr, curl, pillar, pingr, processx (>= 3.1.0), R6,
+rlang, testthat (>= 3.0.0), webfakes"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"pscl"	"pscl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.5.1"	NA	NA	"MASS, datasets, grDevices, graphics, stats, utils"	NA	"lattice, MCMCpack, car, lmtest, sandwich, zoo, coda, vcd,
+mvtnorm, mgcv"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"psgp"	"psgp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3-20"	NA	"R (>= 3.0.2), intamap"	"gstat, automap, sp, doParallel, foreach, parallel, Rcpp"	"Rcpp, RcppArmadillo (>= 0.2.0)"	"sf"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"purrr"	"purrr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.1"	NA	"R (>= 3.4.0)"	"cli (>= 3.4.0), lifecycle (>= 1.0.3), magrittr (>= 1.5.0),
+rlang (>= 0.4.10), vctrs (>= 0.5.0)"	"cli"	"covr, dplyr (>= 0.7.8), httr, knitr, lubridate, rmarkdown,
+testthat (>= 3.0.0), tibble, tidyselect"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"quadprog"	"quadprog"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5-8"	NA	"R (>= 3.1.0)"	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
+"quantreg"	"quantreg"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"5.96"	NA	"R (>= 3.5), stats, SparseM"	"methods, graphics, Matrix, MatrixModels, survival, MASS"	NA	"interp, rgl, logspline, nor1mix, Formula, zoo, R.rsp, conquer"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"R.cache"	"R.cache"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.16.0"	NA	"R (>= 2.14.0)"	"utils, R.methodsS3 (>= 1.8.1), R.oo (>= 1.24.0), R.utils (>=
+2.10.1), digest (>= 0.6.13)"	NA	NA	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"R.devices"	"R.devices"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.17.1"	NA	"R (>= 2.14.0)"	"grDevices, R.methodsS3 (>= 1.8.1), R.oo (>= 1.24.0), R.utils
+(>= 2.10.1), base64enc (>= 0.1-2)"	NA	"digest (>= 0.6.13), Cairo (>= 1.5-9), R.rsp"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"R.methodsS3"	"R.methodsS3"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8.2"	NA	"R (>= 2.13.0)"	"utils"	NA	"codetools"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.2"
+"R.oo"	"R.oo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.25.0"	NA	"R (>= 2.13.0), R.methodsS3 (>= 1.8.1)"	"methods, utils"	NA	"tools"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.2"
+"R.rsp"	"R.rsp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.45.0"	NA	"R (>= 2.14.0)"	"methods, stats, tools, utils, R.methodsS3 (>= 1.8.0), R.oo (>=
+1.23.0), R.utils, R.cache, digest"	NA	"tcltk, markdown, knitr, R.devices, base64enc, ascii"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"R.utils"	"R.utils"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.12.2"	NA	"R (>= 2.14.0), R.oo"	"methods, utils, tools, R.methodsS3"	NA	"datasets, digest (>= 0.6.10)"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"no"	"4.2.3"
+"R2jags"	"R2jags"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.7-1"	NA	"R (>= 2.14.0), rjags (>= 3-3)"	"abind, coda (>= 0.13), graphics, grDevices, methods,
+R2WinBUGS, parallel, stats, utils"	NA	"testthat (>= 3.0.0)"	NA	"GPL (> 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"R2OpenBUGS"	"R2OpenBUGS"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.2-3.2.1"	NA	"R (>= 2.13.0)"	"coda (>= 0.11-0), boot"	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"R2WinBUGS"	"R2WinBUGS"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1-21"	NA	"R (>= 2.13.0), coda (>= 0.11-0), boot"	"utils, stats, graphics"	NA	"BRugs (>= 0.3-2)"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"R6"	"R6"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.5.1"	NA	"R (>= 3.0)"	NA	NA	"testthat, pryr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"ragg"	"ragg"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.5"	NA	NA	"systemfonts (>= 1.0.3), textshaping (>= 0.3.0)"	"systemfonts, textshaping"	"covr, graphics, grid, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"randomForest"	"randomForest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4.7-1.1"	NA	"R (>= 4.1.0), stats"	NA	NA	"RColorBrewer, MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"randomNames"	"randomNames"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5-0.0"	NA	"R (>= 4.0)"	"crayon, data.table (>= 1.14.0), toOrdinal (>= 1.1)"	NA	"knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"RANN"	"RANN"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.6.1"	NA	NA	NA	NA	"testthat"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rappdirs"	"rappdirs"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.3"	NA	"R (>= 3.2)"	NA	NA	"roxygen2, testthat (>= 3.0.0), covr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"raster"	"raster"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.6-23"	NA	"sp (>= 1.4-5), R (>= 3.5.0)"	"Rcpp, methods, terra (>= 1.7-29)"	"Rcpp"	"ncdf4, igraph, tcltk, parallel, rasterVis, MASS, sf,
+tinytest, gstat, fields, exactextractr"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ratelimitr"	"ratelimitr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.1"	NA	NA	"assertthat"	NA	"testthat, microbenchmark, knitr, rmarkdown, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rcmdcheck"	"rcmdcheck"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.0"	NA	NA	"callr (>= 3.1.1.9000), cli (>= 3.0.0), curl, desc (>= 1.2.0),
 digest, pkgbuild, prettyunits, R6, rprojroot, sessioninfo (>=
 1.1.1), utils, withr, xopen"	NA	"covr, knitr, mockery, processx, ps, rmarkdown, svglite,
-testthat, webfakes"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"RColorBrewer"	"RColorBrewer"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-3"	NA	"R (>= 2.0.0)"	NA	NA	NA	NA	"Apache License 2.0"	NA	NA	NA	NA	"no"	"4.2.0"
-"Rcpp"	"Rcpp"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.8.3"	NA	NA	"methods, utils"	NA	"tinytest, inline, rbenchmark, pkgKitten (>= 0.1.2)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"RcppCCTZ"	"RcppCCTZ"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.10"	NA	NA	"Rcpp (>= 0.11.0)"	"Rcpp"	"tinytest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"RcppParallel"	"RcppParallel"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"5.1.5"	NA	"R (>= 3.0.2)"	NA	NA	"Rcpp, RUnit, knitr, rmarkdown"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"RcppZiggurat"	"RcppZiggurat"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.6"	NA	"R (>= 3.0.0)"	"Rcpp, parallel, graphics, stats, utils"	"Rcpp, RcppGSL"	"rbenchmark, microbenchmark, lattice, knitr, rmarkdown, pinp"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"RCurl"	"RCurl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.98-1.6"	NA	"R (>= 3.4.0), methods"	"bitops"	NA	"XML"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"readr"	"readr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.2"	NA	"R (>= 3.1)"	"cli (>= 3.0.0), clipr, crayon, hms (>= 0.4.1), lifecycle (>=
-0.2.0), methods, R6, rlang, tibble, utils, vroom (>= 1.5.6)"	"cpp11, tzdb (>= 0.1.1)"	"covr, curl, datasets, knitr, rmarkdown, spelling, stringi,
-testthat (>= 3.1.2), tzdb (>= 0.1.1), waldo, withr, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rematch2"	"rematch2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.2"	NA	NA	"tibble"	NA	"covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"remotes"	"remotes"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.4.2"	NA	"R (>= 3.0.0)"	"methods, stats, tools, utils"	NA	"brew, callr, codetools, curl, covr, git2r (>= 0.23.0), knitr,
+testthat, webfakes"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"RColorBrewer"	"RColorBrewer"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-3"	NA	"R (>= 2.0.0)"	NA	NA	NA	NA	"Apache License 2.0"	NA	NA	NA	NA	"no"	"4.2.0"
+"Rcpp"	"Rcpp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.11"	NA	NA	"methods, utils"	NA	"tinytest, inline, rbenchmark, pkgKitten (>= 0.1.2)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"RcppCCTZ"	"RcppCCTZ"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.12"	NA	NA	"Rcpp (>= 0.11.0)"	"Rcpp"	"tinytest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"RcppParallel"	"RcppParallel"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"5.1.7"	NA	"R (>= 3.0.2)"	NA	NA	"Rcpp, RUnit, knitr, rmarkdown"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"RcppZiggurat"	"RcppZiggurat"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.6"	NA	"R (>= 3.0.0)"	"Rcpp, parallel, graphics, stats, utils"	"Rcpp, RcppGSL"	"rbenchmark, microbenchmark, lattice, knitr, rmarkdown, pinp"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"RCurl"	"RCurl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.98-1.12"	NA	"R (>= 3.4.0), methods"	"bitops"	NA	"XML"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"readr"	"readr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.4"	NA	"R (>= 3.5)"	"cli (>= 3.2.0), clipr, crayon, hms (>= 0.4.1), lifecycle (>=
+0.2.0), methods, R6, rlang, tibble, utils, vroom (>= 1.6.0)"	"cpp11, tzdb (>= 0.1.1)"	"covr, curl, datasets, knitr, rmarkdown, spelling, stringi,
+testthat (>= 3.1.2), tzdb (>= 0.1.1), waldo, withr, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rematch2"	"rematch2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.2"	NA	NA	"tibble"	NA	"covr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"remotes"	"remotes"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.4.2.1"	NA	"R (>= 3.0.0)"	"methods, stats, tools, utils"	NA	"brew, callr, codetools, curl, covr, git2r (>= 0.23.0), knitr,
 mockery, pkgbuild (>= 1.0.1), pingr, rmarkdown, rprojroot,
-testthat, webfakes, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rentrez"	"rentrez"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.3"	NA	"R (>= 2.6.0)"	"XML, httr (>= 0.5), jsonlite (>= 0.9)"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"renv"	"renv"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.15.4"	NA	NA	"utils"	NA	"R6, BiocManager, cli, covr, devtools, knitr, miniUI, packrat,
-pak, remotes, reticulate, rmarkdown, rstudioapi, shiny,
-testthat, uuid, yaml"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"reshape"	"reshape"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8.9"	NA	"R (>= 2.6.1)"	"plyr"	NA	NA	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"reshape2"	"reshape2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.4"	NA	"R (>= 3.1)"	"plyr (>= 1.8.1), Rcpp, stringr"	"Rcpp"	"covr, lattice, testthat (>= 0.8.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rex"	"rex"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.1"	NA	NA	"lazyeval"	NA	"covr, dplyr, ggplot2, Hmisc, knitr, magrittr, rmarkdown,
-roxygen2, rvest, stringr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rgdal"	"rgdal"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-32"	NA	"R (>= 3.5.0), methods, sp (>= 1.1-0)"	"grDevices, graphics, stats, utils"	"sp"	"knitr, DBI, RSQLite, maptools, mapview, rmarkdown, curl,
-rgeos"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rgeos"	"rgeos"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5-9"	NA	"R (>= 3.3.0), methods, sp (>= 1.1-0)"	"utils, stats, graphics"	"sp"	"maptools (>= 0.8-5), testthat, XML, maps, rgdal"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ritis"	"ritis"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.0"	NA	NA	"solrium (>= 1.1.4), crul (>= 0.9.0), jsonlite, data.table,
-tibble"	NA	"testthat, webmockr, vcr (>= 0.5.4)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rjags"	"rjags"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"4-13"	NA	"R (>= 2.14.0), coda (>= 0.13)"	NA	NA	"tcltk"	NA	"GPL (== 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rjson"	"rjson"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.2.21"	NA	"R (>= 4.0.0)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rlang"	"rlang"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.2"	NA	"R (>= 3.4.0)"	"utils"	NA	"cli (>= 3.1.0), covr, crayon, fs, glue, knitr, magrittr,
+testthat, webfakes, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rentrez"	"rentrez"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.3"	NA	"R (>= 2.6.0)"	"XML, httr (>= 0.5), jsonlite (>= 0.9)"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"renv"	"renv"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.3"	NA	NA	"utils"	NA	"BiocManager, cli, covr, cpp11, devtools, gitcreds, jsonlite,
+knitr, miniUI, packrat, pak, R6, remotes, reticulate,
+rmarkdown, rstudioapi, shiny, testthat, uuid, waldo, yaml,
+webfakes"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"reshape"	"reshape"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.8.9"	NA	"R (>= 2.6.1)"	"plyr"	NA	NA	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"reshape2"	"reshape2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.4"	NA	"R (>= 3.1)"	"plyr (>= 1.8.1), Rcpp, stringr"	"Rcpp"	"covr, lattice, testthat (>= 0.8.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rex"	"rex"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.1"	NA	NA	"lazyeval"	NA	"covr, dplyr, ggplot2, Hmisc, knitr, magrittr, rmarkdown,
+roxygen2, rvest, stringr, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rgdal"	"rgdal"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6-7"	NA	"R (>= 3.5.0), methods, sp (>= 1.1-0)"	"grDevices, graphics, stats, utils"	"sp"	"knitr, DBI, RSQLite, maptools, mapview, rmarkdown, curl,
+rgeos"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rgeos"	"rgeos"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6-4"	NA	"R (>= 3.3.0), methods, sp (>= 1.1-0)"	"utils, stats, graphics"	"sp"	"maptools (>= 0.8-5), testthat, XML, maps, rgdal"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ritis"	"ritis"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	NA	"solrium (>= 1.1.4), crul (>= 0.9.0), jsonlite, data.table,
+tibble"	NA	"testthat, webmockr, vcr (>= 0.5.4)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rjags"	"rjags"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"4-14"	NA	"R (>= 2.14.0), coda (>= 0.13)"	NA	NA	"tcltk"	NA	"GPL (== 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rjson"	"rjson"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.21"	NA	"R (>= 4.0.0)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
+"rlang"	"rlang"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.1"	NA	"R (>= 3.5.0)"	"utils"	NA	"cli (>= 3.1.0), covr, crayon, fs, glue, knitr, magrittr,
 methods, pillar, rmarkdown, stats, testthat (>= 3.0.0), tibble,
-usethis, vctrs (>= 0.2.3), withr"	"winch"	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rmarkdown"	"rmarkdown"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.14"	NA	"R (>= 3.0)"	"bslib (>= 0.2.5.1), evaluate (>= 0.13), htmltools (>= 0.3.5),
-jquerylib, jsonlite, knitr (>= 1.22), methods, stringr (>=
-1.2.0), tinytex (>= 0.31), tools, utils, xfun (>= 0.30), yaml
-(>= 2.1.19)"	NA	"digest, dygraphs, fs, rsconnect, downlit (>= 0.4.0), katex
+usethis, vctrs (>= 0.2.3), withr"	"winch"	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rmarkdown"	"rmarkdown"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.23"	NA	"R (>= 3.0)"	"bslib (>= 0.2.5.1), evaluate (>= 0.13), fontawesome (>=
+0.5.0), htmltools (>= 0.5.1), jquerylib, jsonlite, knitr (>=
+1.22), methods, stringr (>= 1.2.0), tinytex (>= 0.31), tools,
+utils, xfun (>= 0.36), yaml (>= 2.1.19)"	NA	"digest, dygraphs, fs, rsconnect, downlit (>= 0.4.0), katex
 (>= 1.4.0), sass (>= 0.4.0), shiny (>= 1.6.0), testthat (>=
-3.0.3), tibble, tufte, vctrs, withr (>= 2.4.2)"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"Rmisc"	"Rmisc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.1"	NA	"lattice, plyr"	NA	NA	"latticeExtra, Hmisc, stats4"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"rms"	"rms"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"6.3-0"	NA	"R (>= 3.5.0), Hmisc (>= 4.7-0), survival (>= 3.1-12), lattice,
-ggplot2 (>= 2.2), SparseM"	"methods, quantreg, rpart, nlme (>= 3.1-123), polspline,
-multcomp, htmlTable (>= 1.11.0), htmltools, MASS, cluster,
-digest"	NA	"boot, tcltk, plotly (>= 4.5.6), knitr, mice, rmsb, nnet, VGAM"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rmsb"	"rmsb"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.1.0"	NA	"R (>= 3.4.0), rms (>= 6.0.2)"	"methods, Rcpp (>= 0.12.0), RcppParallel (>= 5.0.1), rstan (>=
+3.0.3), tibble, vctrs, cleanrmd, withr (>= 2.4.2)"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"Rmisc"	"Rmisc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.1"	NA	"lattice, plyr"	NA	NA	"latticeExtra, Hmisc, stats4"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"rms"	"rms"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"6.7-0"	NA	"R (>= 3.5.0), Hmisc (>= 5.1-0)"	"methods, survival, quantreg, ggplot2, SparseM, rpart, nlme (>=
+3.1-123), polspline, multcomp, htmlTable (>= 1.11.0),
+htmltools, MASS, cluster, digest, colorspace, knitr, grDevices"	NA	"boot, tcltk, plotly (>= 4.5.6), mice, rmsb, nnet, VGAM,
+lattice, kableExtra"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rmsb"	"rmsb"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.0"	NA	"R (>= 3.4.0), rms (>= 6.0.2)"	"methods, Rcpp (>= 0.12.0), RcppParallel (>= 5.0.1), rstan (>=
 2.18.1), rstantools (>= 2.1.1), Hmisc (>= 4.3-0), survival (>=
 3.1-12), ggplot2, MASS, cluster, digest, knitr, loo"	"BH (>= 1.66.0), Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0),
 RcppParallel (>= 5.0.1), rstan (>= 2.18.1), StanHeaders (>=
-2.18.0)"	"mice"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rncl"	"rncl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8.6"	NA	"R (>= 3.1.1)"	"Rcpp (>= 0.11.0), progress (>= 1.1.2), stats"	"Rcpp, progress"	"testthat, ape"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rngtools"	"rngtools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.2"	NA	"R (>= 3.2.0), methods"	"digest, utils, stats, parallel"	NA	"covr, RUnit, testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"robust"	"robust"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.7-0"	NA	"fit.models"	"graphics, stats, utils, lattice, MASS, robustbase, rrcov"	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"robustbase"	"robustbase"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.95-0"	NA	"R (>= 3.5.0)"	"stats, graphics, utils, methods, DEoptimR"	NA	"grid, MASS, lattice, boot, cluster, Matrix, robust,
+2.18.0)"	"mice"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rncl"	"rncl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.8.7"	NA	"R (>= 3.1.1)"	"Rcpp (>= 0.11.0), progress (>= 1.1.2), stats"	"Rcpp, progress"	"testthat, ape"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rngtools"	"rngtools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.2"	NA	"R (>= 3.2.0), methods"	"digest, utils, stats, parallel"	NA	"covr, RUnit, testthat"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"robust"	"robust"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.7-2"	NA	"fit.models"	"graphics, stats, utils, lattice, MASS, robustbase, rrcov"	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"robustbase"	"robustbase"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.99-0"	NA	"R (>= 3.5.0)"	"stats, graphics, utils, methods, DEoptimR"	NA	"grid, MASS, lattice, boot, cluster, Matrix, robust,
 fit.models, MPV, xtable, ggplot2, GGally, RColorBrewer,
-reshape2, sfsmisc, catdata, doParallel, foreach, skewt"	"robustX, rrcov, matrixStats, quantreg, Hmisc"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rotl"	"rotl"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.0.12"	NA	"R (>= 3.1.1)"	"ape, assertthat (>= 0.1), httr, jsonlite, rentrez, rncl (>=
+reshape2, sfsmisc, catdata, doParallel, foreach, skewt"	"robustX, rrcov, matrixStats, quantreg, Hmisc"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rotl"	"rotl"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1.0"	NA	"R (>= 3.1.1)"	"ape, curl (>= 3.0.0), httr, jsonlite, rentrez, rlang, rncl (>=
 0.6.0)"	NA	"knitr (>= 1.12), MCMCglmm, phylobase, readxl, rmarkdown (>=
-0.7), RNeXML, testthat"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"roxygen2"	"roxygen2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"7.2.0"	NA	"R (>= 3.3)"	"brew, cli (>= 3.3.0), commonmark, desc (>= 1.2.0), digest,
-knitr, methods, pkgload (>= 1.0.2), purrr (>= 0.3.3), R6 (>=
-2.1.2), rlang (>= 1.0.0), stringi, stringr (>= 1.0.0), utils,
-withr, xml2"	"cpp11"	"covr, R.methodsS3, R.oo, rmarkdown, testthat (>= 3.1.2),"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rprojroot"	"rprojroot"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.3"	NA	"R (>= 3.0.0)"	NA	NA	"covr, knitr, lifecycle, mockr, rmarkdown, testthat (>=
-3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rrcov"	"rrcov"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7-0"	NA	"R (>= 2.10), robustbase (>= 0.92.1), methods"	"stats, stats4, mvtnorm, lattice, pcaPP"	NA	"grid, MASS"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rredlist"	"rredlist"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.7.0"	NA	NA	"crul (>= 0.3.8), jsonlite (>= 1.1)"	NA	"testthat, vcr (>= 0.4.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"RSQLite"	"RSQLite"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2.14"	NA	"R (>= 3.1.0)"	"bit64, blob (>= 1.2.0), DBI (>= 1.1.0), memoise, methods,
-pkgconfig, Rcpp (>= 1.0.7)"	"plogr (>= 0.2.0), Rcpp"	"callr, DBItest (>= 1.7.0), gert, gh, knitr, rmarkdown, hms,
-rvest, testthat, xml2"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rstan"	"rstan"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.21.5"	NA	"R (>= 3.4.0), StanHeaders (>= 2.21.0), ggplot2 (>= 3.0.0)"	"methods, stats4, inline, gridExtra (>= 2.0.0), Rcpp (>=
+0.7), RNeXML, testthat"	NA	"BSD_2_clause + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"roxygen2"	"roxygen2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"7.2.3"	NA	"R (>= 3.3)"	"brew, cli (>= 3.3.0), commonmark, desc (>= 1.2.0), knitr,
+methods, pkgload (>= 1.0.2), purrr (>= 0.3.3), R6 (>= 2.1.2),
+rlang (>= 1.0.6), stringi, stringr (>= 1.0.0), utils, withr,
+xml2"	"cpp11"	"covr, R.methodsS3, R.oo, rmarkdown (>= 2.16), testthat (>=
+3.1.2), yaml"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rprojroot"	"rprojroot"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0.3"	NA	"R (>= 3.0.0)"	NA	NA	"covr, knitr, lifecycle, mockr, rmarkdown, testthat (>=
+3.0.0), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rrcov"	"rrcov"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7-4"	NA	"R (>= 2.10), robustbase (>= 0.92.1), methods"	"stats, stats4, mvtnorm, lattice, pcaPP"	NA	"grid, MASS"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rredlist"	"rredlist"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.7.1"	NA	NA	"crul (>= 0.3.8), jsonlite (>= 1.1)"	NA	"testthat, vcr (>= 0.4.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"RSQLite"	"RSQLite"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.1"	NA	"R (>= 3.1.0)"	"bit64, blob (>= 1.2.0), DBI (>= 1.1.0), memoise, methods,
+pkgconfig"	"plogr (>= 0.2.0), cpp11 (>= 0.4.0)"	"callr, DBItest (>= 1.7.2.9001), gert, gh, hms, knitr,
+magrittr, rmarkdown, rvest, testthat (>= 3.0.0), withr, xml2"	NA	"LGPL (>= 2.1)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rstan"	"rstan"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.21.8"	NA	"R (>= 3.4.0), StanHeaders (>= 2.21.0), ggplot2 (>= 3.0.0)"	"methods, stats4, inline, gridExtra (>= 2.0.0), Rcpp (>=
 0.12.0), RcppParallel (>= 5.0.1), loo (>= 2.3.0), pkgbuild"	"Rcpp (>= 0.12.0), RcppEigen (>= 0.3.3.3.0), BH (>=
 1.72.0-2), StanHeaders (>= 2.21.0), RcppParallel"	"RUnit, RcppEigen (>= 0.3.3.3.0), BH (>= 1.72.0-2), parallel,
 KernSmooth, shinystan (>= 2.3.0), bayesplot (>= 1.5.0),
 rmarkdown, rstantools, rstudioapi, Matrix, knitr (>= 1.15.1),
-V8"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rstantools"	"rstantools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2.0"	NA	NA	"desc, stats, utils, Rcpp (>= 0.12.16), RcppParallel (>= 5.0.1)"	NA	"rstan (>= 2.17.2), usethis (>= 1.5.1), testthat (>= 2.0.0),
+V8"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"rstantools"	"rstantools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.1.1"	NA	NA	"desc, stats, utils, Rcpp (>= 0.12.16), RcppParallel (>= 5.0.1)"	NA	"rstan (>= 2.17.2), usethis (>= 1.5.1), testthat (>= 2.0.0),
 knitr, pkgbuild, pkgload, roxygen2 (>= 6.0.1), rmarkdown,
-rstudioapi"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"rstudioapi"	"rstudioapi"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.13"	NA	NA	NA	NA	"testthat, knitr, rmarkdown, clipr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"rversions"	"rversions"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.1"	NA	NA	"curl, utils, xml2 (>= 1.0.0)"	NA	"mockery, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"s2"	"s2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.7"	NA	"R (>= 3.0.0)"	"Rcpp, wk (>= 0.5.0)"	"Rcpp, wk"	"testthat, vctrs"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"sandwich"	"sandwich"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.0-1"	NA	"R (>= 3.0.0)"	"stats, utils, zoo"	NA	"AER, car, geepack, lattice, lmtest, MASS, multiwayvcov,
+rstudioapi"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"rstudioapi"	"rstudioapi"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.15.0"	NA	NA	NA	NA	"testthat, knitr, rmarkdown, clipr, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rversions"	"rversions"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.2"	NA	NA	"curl, utils, xml2 (>= 1.0.0)"	NA	"covr, mockery, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"rvest"	"rvest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.3"	NA	"R (>= 3.2)"	"glue, cli, httr (>= 0.5), lifecycle (>= 1.0.0), magrittr,
+rlang (>= 1.0.0), selectr, tibble, xml2 (>= 1.3), withr"	NA	"covr, knitr, readr, repurrrsive, rmarkdown, spelling, stringi
+(>= 0.3.1), testthat (>= 3.0.2), webfakes"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"s2"	"s2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1.4"	NA	"R (>= 3.0.0)"	"Rcpp, wk (>= 0.6.0)"	"Rcpp, wk"	"bit64, testthat (>= 3.0.0), vctrs"	NA	"Apache License (== 2.0)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"sandwich"	"sandwich"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.0-2"	NA	"R (>= 3.0.0)"	"stats, utils, zoo"	NA	"AER, car, geepack, lattice, lme4, lmtest, MASS, multiwayvcov,
 parallel, pcse, plm, pscl, scatterplot3d, stats4, strucchange,
-survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"sass"	"sass"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.1"	NA	NA	"fs, rlang (>= 0.4.10), htmltools (>= 0.5.1), R6, rappdirs"	NA	"testthat, knitr, rmarkdown, withr, shiny, curl"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"satellite"	"satellite"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.4"	NA	"R (>= 2.10), raster, methods, utils, stats, grDevices,
-graphics"	"plyr, Rcpp (>= 0.10.3), terra, tools, stats4"	"Rcpp"	"devtools, knitr, rgdal, testthat, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"scales"	"scales"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	"R (>= 3.2)"	"farver (>= 2.0.3), labeling, lifecycle, munsell (>= 0.5), R6,
+survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"sass"	"sass"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.7"	NA	NA	"fs (>= 1.2.4), rlang (>= 0.4.10), htmltools (>= 0.5.1), R6,
+rappdirs"	NA	"testthat, knitr, rmarkdown, withr, shiny, curl"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"satellite"	"satellite"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.4"	NA	"R (>= 2.10), raster, methods, utils, stats, grDevices,
+graphics"	"plyr, Rcpp (>= 0.10.3), terra, tools, stats4"	"Rcpp"	"devtools, knitr, rgdal, testthat, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"scales"	"scales"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.1"	NA	"R (>= 3.2)"	"farver (>= 2.0.3), labeling, lifecycle, munsell (>= 0.5), R6,
 RColorBrewer, rlang (>= 1.0.0), viridisLite"	NA	"bit64, covr, dichromat, ggplot2, hms (>= 0.5.0), stringi,
-testthat (>= 3.0.0), waldo (>= 0.4.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"servr"	"servr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.24"	NA	"R (>= 3.0.0)"	"mime (>= 0.2), httpuv (>= 1.5.2), xfun, jsonlite"	NA	"tools, later, rstudioapi, knitr (>= 1.9), rmarkdown"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"sessioninfo"	"sessioninfo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.2"	NA	"R (>= 2.10)"	"cli (>= 3.1.0), tools, utils"	NA	"callr, covr, mockery, reticulate, rmarkdown, testthat, withr"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"sf"	"sf"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-7"	NA	"methods, R (>= 3.3.0)"	"classInt (>= 0.4-1), DBI (>= 0.8), graphics, grDevices, grid,
-magrittr, Rcpp (>= 0.12.18), s2 (>= 1.0.7), stats, tools, units
+testthat (>= 3.0.0), waldo (>= 0.4.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"selectr"	"selectr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4-2"	NA	"R (>= 3.0)"	"methods, stringr, R6"	NA	"testthat, XML, xml2"	NA	"BSD_3_clause + file LICENCE"	NA	NA	NA	NA	"no"	"4.2.3"
+"servr"	"servr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.27"	NA	"R (>= 3.0.0)"	"mime (>= 0.2), httpuv (>= 1.5.2), xfun, jsonlite"	NA	"tools, later, rstudioapi, knitr (>= 1.9), rmarkdown"	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.3"
+"sessioninfo"	"sessioninfo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.2"	NA	"R (>= 2.10)"	"cli (>= 3.1.0), tools, utils"	NA	"callr, covr, mockery, reticulate, rmarkdown, testthat, withr"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"sf"	"sf"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-14"	NA	"methods, R (>= 3.3.0)"	"classInt (>= 0.4-1), DBI (>= 0.8), graphics, grDevices, grid,
+magrittr, Rcpp (>= 0.12.18), s2 (>= 1.1.0), stats, tools, units
 (>= 0.7-0), utils"	"Rcpp"	"blob, covr, dplyr (>= 0.8-3), ggplot2, knitr, lwgeom (>=
-0.2-1), maps, mapview, Matrix, microbenchmark, odbc, pillar,
-pool, raster, rlang, rmarkdown, RPostgres (>= 1.1.0),
+0.2-1), maps, mapview, Matrix, microbenchmark, odbc, pbapply,
+pillar, pool, raster, rlang, rmarkdown, RPostgres (>= 1.1.0),
 RPostgreSQL, RSQLite, sp (>= 1.2-4), spatstat (>= 2.0-1),
 spatstat.geom, spatstat.random, spatstat.linnet,
-spatstat.utils, stars (>= 0.2-0), terra, testthat, tibble (>=
-1.4.1), tidyr (>= 1.2.0), tidyselect (>= 1.0.0), tmap (>= 2.0),
-vctrs, wk"	NA	"GPL-2 | MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"sfsmisc"	"sfsmisc"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-13"	NA	"R (>= 3.3.0)"	"grDevices, utils, stats, tools"	NA	"datasets, tcltk, cluster, lattice, MASS, Matrix, nlme, lokern"	"mgcv, rpart, nor1mix, polycor, sm, tikzDevice, e1071, Hmisc,
-gmp, pastecs, polynom, robustbase"	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"sgeostat"	"sgeostat"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-27"	NA	"stats, grDevices, graphics, R (>= 2.0.0)"	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"SGP"	"SGP"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.9-5.0"	NA	"R (>= 3.6.0)"	"Cairo, callr, colorspace, crayon, datasets, data.table (>=
-1.12.4), digest, doParallel, doRNG (>= 1.8.2), equate (>=
+spatstat.utils, stars (>= 0.2-0), terra, testthat (>= 3.0.0),
+tibble (>= 1.4.1), tidyr (>= 1.2.0), tidyselect (>= 1.0.0),
+tmap (>= 2.0), vctrs, wk"	NA	"GPL-2 | MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"sfsmisc"	"sfsmisc"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-16"	NA	"R (>= 3.3.0)"	"grDevices, utils, stats, tools"	NA	"datasets, tcltk, cluster, lattice, MASS, Matrix, nlme,
+lokern, Rmpfr, gmp"	"mgcv, rpart, nor1mix, polycor, sm, tikzDevice, e1071, Hmisc,
+pastecs, polynom, robustbase"	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"sftime"	"sftime"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2-0"	NA	"sf (>= 1.0.7)"	"methods"	NA	"knitr, spacetime, rmarkdown, dplyr (>= 0.8-3), trajectories
+(>= 0.2.2), stars, ncmeta, tidyr, ggplot2, magrittr, sp, rlang"	NA	"Apache License"	NA	NA	NA	NA	"no"	"4.2.3"
+"sgeostat"	"sgeostat"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0-27"	NA	"stats, grDevices, graphics, R (>= 2.0.0)"	NA	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
+"SGP"	"SGP"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0-0.0"	NA	"R (>= 4.0.0)"	"Cairo, callr, colorspace, crayon, datasets, data.table (>=
+1.14.0), digest, doParallel, doRNG (>= 1.8.2), equate (>=
 2.0-5), foreach, graphics, grid, grDevices, gridBase,
 iterators, gtools, jsonlite, matrixStats, methods, parallel,
 plotly, quantreg, randomNames (>= 0.0-5), rngtools (>= 1.5),
-RSQLite, sn (>= 1.0-0), splines, stats, toOrdinal, utils"	NA	"SGPdata (>= 23.0-0), knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"shape"	"shape"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.6"	NA	"R (>= 2.01)"	"stats, graphics, grDevices"	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"simplermarkdown"	"simplermarkdown"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.0.4"	NA	NA	"rjson, tools"	NA	"MASS"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
-"skewt"	"skewt"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0"	NA	NA	NA	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"sn"	"sn"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.0.2"	NA	"R (>= 3.0.0), methods, stats4"	"mnormt (>= 2.0.0), numDeriv, utils, quantreg"	NA	"R.rsp"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"solrium"	"solrium"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	NA	"utils, dplyr (>= 0.5.0), plyr (>= 1.8.4), crul (>= 0.4.0),
-xml2 (>= 1.0.0), jsonlite (>= 1.0), tibble (>= 1.4.2), R6"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"sp"	"sp"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4-7"	NA	"R (>= 3.0.0), methods"	"utils, stats, graphics, grDevices, lattice, grid"	NA	"RColorBrewer, rgdal (>= 1.2-3), rgeos (>= 0.3-13), gstat,
-maptools, deldir, knitr, rmarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spacetime"	"spacetime"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2-6"	NA	"R (>= 3.0.0)"	"graphics, utils, stats, methods, lattice, sp (>= 1.1-0), zoo
+RSQLite, sn (>= 1.0-0), splines, stats, toOrdinal, utils"	NA	"SGPdata (>= 26.0-0), knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"shape"	"shape"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.6"	NA	"R (>= 2.01)"	"stats, graphics, grDevices"	NA	NA	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.0"
+"shiny"	"shiny"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7.4.1"	NA	"R (>= 3.0.2), methods"	"utils, grDevices, httpuv (>= 1.5.2), mime (>= 0.3), jsonlite
+(>= 0.9.16), xtable, fontawesome (>= 0.4.0), htmltools (>=
+0.5.4), R6 (>= 2.0), sourcetools, later (>= 1.0.0), promises
+(>= 1.1.0), tools, crayon, rlang (>= 0.4.10), fastmap (>=
+1.1.0), withr, commonmark (>= 1.7), glue (>= 1.3.2), bslib (>=
+0.3.0), cachem, ellipsis, lifecycle (>= 0.2.0)"	NA	"datasets, Cairo (>= 1.5-5), testthat (>= 3.0.0), knitr (>=
+1.6), markdown, rmarkdown, ggplot2, reactlog (>= 1.0.0),
+magrittr, yaml, future, dygraphs, ragg, showtext, sass"	NA	"GPL-3 | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"simplermarkdown"	"simplermarkdown"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.0.6"	NA	NA	"rjson, tools"	NA	"MASS"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
+"skewt"	"skewt"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0"	NA	NA	NA	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
+"sn"	"sn"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.1"	NA	"R (>= 3.0.0), methods, stats4"	"mnormt (>= 2.0.0), numDeriv, utils, quantreg"	NA	"R.rsp"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"solrium"	"solrium"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.0"	NA	NA	"utils, dplyr (>= 0.5.0), plyr (>= 1.8.4), crul (>= 0.4.0),
+xml2 (>= 1.0.0), jsonlite (>= 1.0), tibble (>= 1.4.2), R6"	NA	"testthat, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"sourcetools"	"sourcetools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.1.7-1"	NA	"R (>= 3.0.2)"	NA	NA	"testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"sp"	"sp"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.0-0"	NA	"R (>= 3.2.0), methods"	"utils, stats, graphics, grDevices, lattice, grid"	NA	"RColorBrewer, rgdal (>= 1.2-3), rgeos (>= 0.3-13), gstat,
+maptools, deldir, knitr, rmarkdown, sf, terra, raster"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"spacetime"	"spacetime"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3-0"	NA	"R (>= 3.0.0)"	"graphics, utils, stats, methods, lattice, sp (>= 1.1-0), zoo
 (>= 1.7-9), xts (>= 0.8-8), intervals"	NA	"adehabitatLT, cshapes (>= 2.0), foreign, gstat (>= 1.0-16),
-maps, mapdata, maptools, plm, raster, RColorBrewer, rgdal,
-rgeos, rmarkdown, RPostgreSQL, knitr, googleVis, ISOcodes,
-markdown, sf"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"spam"	"spam"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.8-0"	NA	"R (>= 3.1)"	"dotCall64, grid, methods"	NA	"spam64, fields, Matrix, testthat, R.rsp, truncdist, knitr,
-rmarkdown"	NA	"LGPL-2 | BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"SparseM"	"SparseM"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.81"	NA	"R (>= 2.15), methods"	"graphics, stats, utils"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spatstat.data"	"spatstat.data"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2-0"	NA	"R (>= 3.5.0)"	"spatstat.utils (>= 2.1-0), Matrix"	NA	"spatstat.geom, spatstat.random, spatstat.core,
-spatstat.linnet"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"spatstat.geom"	"spatstat.geom"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.4-0"	NA	"R (>= 3.5.0), spatstat.data (>= 2.0-0), stats, graphics,
-grDevices, utils, methods"	"spatstat.utils (>= 2.2-0), deldir (>= 1.0-2), polyclip (>=
-1.10-0)"	NA	"spatstat.core, spatstat.random, spatstat.linnet, maptools (>=
-0.9-9), spatial, fftwtools (>= 0.9-8), spatstat (>= 2.0-0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spatstat.random"	"spatstat.random"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2-0"	NA	"R (>= 3.5.0), spatstat.data (>= 2.1-0), spatstat.geom (>=
-2.4-0), stats, utils, methods, grDevices"	"spatstat.utils (>= 2.2-0)"	NA	"spatial, RandomFields (>= 3.1.24.1), RandomFieldsUtils(>=
-0.3.3.1), spatstat.linnet (>= 2.0-0), spatstat.core (>= 2.4-0),
-spatstat (>= 2.3-3)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spatstat.utils"	"spatstat.utils"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3-1"	NA	"R (>= 3.3.0), stats, graphics, grDevices, utils, methods"	NA	NA	"spatstat.core"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spelling"	"spelling"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2"	NA	NA	"commonmark, xml2, hunspell (>= 3.0), knitr"	NA	"pdftools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"splancs"	"splancs"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.01-43"	NA	"R (>= 2.10.0), sp (>= 0.9)"	"stats, graphics, grDevices, methods"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"StanHeaders"	"StanHeaders"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.21.0-7"	NA	"R (>= 3.4.0)"	"RcppParallel (>= 5.0.1)"	"RcppEigen, RcppParallel (>= 5.0.1)"	"Rcpp, BH, knitr (>= 1.15.1), rmarkdown, Matrix, methods,
-rstan"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"stars"	"stars"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5-5"	NA	"R (>= 3.3.0), abind, sf (>= 1.0.3)"	"methods, parallel, classInt (>= 0.4-1), lwgeom, rlang, units"	NA	"PCICt, RNetCDF (>= 1.8-2), clue, covr, cubelyr, digest, dplyr
-(>= 0.7-0), exactextractr, future.apply, ggforce, ggplot2,
-ggthemes, gstat, httr, jsonlite, knitr, maps, mapdata,
-ncdfgeom, ncmeta (>= 0.0.3), pbapply, plm, randomForest,
-raster, rgdal, rmarkdown, sp, spacetime, spatstat (>= 2.0-1),
-spatstat.geom, starsdata, terra (>= 1.4-22), testthat, tidyr,
-viridis, xts, zoo"	NA	"Apache License"	NA	NA	NA	NA	"no"	"4.2.0"
-"stringi"	"stringi"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7.6"	NA	"R (>= 3.1)"	"tools, utils, stats"	NA	NA	NA	"file LICENSE"	"yes"	NA	NA	NA	"yes"	"4.2.0"
-"stringr"	"stringr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.4.0"	NA	"R (>= 3.1)"	"glue (>= 1.2.0), magrittr, stringi (>= 1.1.7)"	NA	"covr, htmltools, htmlwidgets, knitr, rmarkdown, testthat"	NA	"GPL-2 | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"svglite"	"svglite"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.0"	NA	"R (>= 3.0.0)"	"systemfonts (>= 1.0.0)"	"cpp11, systemfonts"	"htmltools, testthat, xml2 (>= 1.0.0), covr, fontquiver (>=
-0.2.0), knitr, rmarkdown"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"sys"	"sys"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.4"	NA	NA	NA	NA	"unix (>= 1.4), spelling, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"systemfonts"	"systemfonts"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.4"	NA	"R (>= 3.2.0)"	NA	"cpp11 (>= 0.2.1)"	"testthat (>= 2.1.0), covr, knitr, rmarkdown, tools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"taxize"	"taxize"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.9.100"	NA	"R(>= 3.2.1)"	"graphics, methods, stats, utils, crul (>= 0.7.0), xml2 (>=
+maps, mapdata, plm, raster, RColorBrewer, rmarkdown,
+RPostgreSQL, knitr, googleVis, ISOcodes, markdown, sf, sftime"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"spam"	"spam"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.9-1"	NA	"R (>= 3.5)"	"dotCall64, grid, methods"	NA	"spam64, fields, Matrix, testthat, R.rsp, truncdist, knitr,
+rmarkdown"	NA	"LGPL-2 | BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"SparseM"	"SparseM"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.81"	NA	"R (>= 2.15), methods"	"graphics, stats, utils"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
+"spatstat.data"	"spatstat.data"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.0-1"	NA	"R (>= 3.5.0)"	"spatstat.utils (>= 3.0-2), Matrix"	NA	"spatstat.geom, spatstat.random, spatstat.explore,
+spatstat.model, spatstat.linnet"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"spatstat.geom"	"spatstat.geom"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.2-4"	NA	"R (>= 3.5.0), spatstat.data (>= 3.0), stats, graphics,
+grDevices, utils, methods"	"spatstat.utils (>= 3.0-2), deldir (>= 1.0-2), polyclip (>=
+1.10-0)"	NA	"spatstat.random, spatstat.explore, spatstat.model,
+spatstat.linnet, maptools (>= 0.9-9), spatial, fftwtools (>=
+0.9-8), spatstat (>= 3.0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"spatstat.random"	"spatstat.random"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1-5"	NA	"R (>= 3.5.0), spatstat.data (>= 3.0), spatstat.geom (>=
+3.2-1), stats, utils, methods, grDevices"	"spatstat.utils (>= 3.0-2)"	NA	"spatial, RandomFields (>= 3.1.24.1), RandomFieldsUtils (>=
+0.3.3.1), spatstat.linnet (>= 3.0), spatstat.explore,
+spatstat.model, spatstat (>= 3.0), gsl"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"spatstat.utils"	"spatstat.utils"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.0-3"	NA	"R (>= 3.3.0), stats, graphics, grDevices, utils, methods"	NA	NA	"spatstat.model"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"spelling"	"spelling"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.2.1"	NA	NA	"commonmark, xml2, hunspell (>= 3.0), knitr"	NA	"pdftools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"splancs"	"splancs"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.01-43"	NA	"R (>= 2.10.0), sp (>= 0.9)"	"stats, graphics, grDevices, methods"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"StanHeaders"	"StanHeaders"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.26.27"	NA	"R (>= 3.4.0)"	"RcppParallel (>= 5.1.4)"	"RcppEigen, RcppParallel (>= 5.1.4)"	"Rcpp, BH (>= 1.75.0-0), knitr (>= 1.36), rmarkdown, Matrix,
+methods, rstan, withr"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"stars"	"stars"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6-2"	NA	"R (>= 3.3.0), abind, sf (>= 1.0-10)"	"methods, parallel, classInt (>= 0.4-1), lwgeom, rlang, units"	NA	"Cairo, OpenStreetMap, PCICt, RNetCDF (>= 1.8-2), clue, covr,
+cubble (>= 0.3.0), cubelyr, digest, dplyr (>= 0.7-0),
+exactextractr, FNN, future.apply, ggforce, ggplot2, ggthemes,
+gstat, httr, jsonlite, knitr, maps, mapdata, ncdfgeom, ncmeta
+(>= 0.0.3), pbapply, plm, randomForest, raster, rmarkdown, sp,
+spacetime, spatstat (>= 2.0-1), spatstat.geom, starsdata, terra
+(>= 1.4-22), testthat, tibble, tidyr, tsibble, viridis, xts,
+zoo"	NA	"Apache License"	NA	NA	NA	NA	"no"	"4.2.3"
+"stringi"	"stringi"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7.12"	NA	"R (>= 3.1)"	"tools, utils, stats"	NA	NA	NA	"file LICENSE"	"yes"	NA	NA	NA	"yes"	"4.2.2"
+"stringr"	"stringr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.0"	NA	"R (>= 3.3)"	"cli, glue (>= 1.6.1), lifecycle (>= 1.0.3), magrittr, rlang
+(>= 1.0.0), stringi (>= 1.5.3), vctrs"	NA	"covr, htmltools, htmlwidgets, knitr, rmarkdown, testthat (>=
+3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"svglite"	"svglite"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.1.1"	NA	"R (>= 3.0.0)"	"systemfonts (>= 1.0.0)"	"cpp11, systemfonts"	"covr, fontquiver (>= 0.2.0), htmltools, knitr, rmarkdown,
+testthat, xml2 (>= 1.0.0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"sys"	"sys"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.4.2"	NA	NA	NA	NA	"unix (>= 1.4), spelling, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"systemfonts"	"systemfonts"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.4"	NA	"R (>= 3.2.0)"	NA	"cpp11 (>= 0.2.1)"	"testthat (>= 2.1.0), covr, knitr, rmarkdown, tools"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"taxize"	"taxize"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.9.100"	NA	"R(>= 3.2.1)"	"graphics, methods, stats, utils, crul (>= 0.7.0), xml2 (>=
 1.2.0), jsonlite, foreach, ape, zoo, data.table, tibble (>=
 1.2), bold (>= 0.8.6), rredlist, rotl (>= 3.0.0), ritis (>=
 0.7.6), worrms (>= 0.4.0), natserv (>= 1.0.0), wikitaxa (>=
-0.3.0), R6, crayon, cli, phangorn, conditionz"	NA	"testthat, vegan, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"terra"	"terra"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5-21"	NA	"R (>= 3.5.0)"	"methods, Rcpp"	"Rcpp"	"parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML, igraph"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"testthat"	"testthat"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1.4"	NA	"R (>= 3.1)"	"brio, callr (>= 3.5.1), cli (>= 3.3.0), crayon (>= 1.3.4),
-desc, digest, ellipsis (>= 0.2.0), evaluate, jsonlite,
-lifecycle, magrittr, methods, pkgload, praise, processx, ps (>=
-1.3.4), R6 (>= 2.2.0), rlang (>= 1.0.1), utils, waldo (>=
-0.4.0), withr (>= 2.4.3)"	NA	"covr, curl (>= 0.9.5), diffviewer (>= 0.1.0), knitr, mockery,
-rmarkdown, rstudioapi, shiny, usethis, vctrs (>= 0.1.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"textshaping"	"textshaping"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.6"	NA	"R (>= 3.2.0)"	"systemfonts (>= 1.0.0)"	"cpp11 (>= 0.2.1), systemfonts (>= 1.0.0)"	"covr, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"TH.data"	"TH.data"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-1"	NA	"R (>= 3.5.0), survival, MASS"	NA	NA	"dplyr, gdata, plyr, trtf, tram, rms, coin, ATR, multcomp,
-gridExtra, vcd, colorspace, lattice, knitr"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"tibble"	"tibble"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.1.7"	NA	"R (>= 3.1.0)"	"ellipsis (>= 0.3.2), fansi (>= 0.4.0), lifecycle (>= 1.0.0),
-magrittr, methods, pillar (>= 1.7.0), pkgconfig, rlang (>=
-1.0.1), utils, vctrs (>= 0.3.8)"	NA	"bench, bit64, blob, brio, callr, cli, covr, crayon (>=
-1.3.4), DiagrammeR, dplyr, evaluate, formattable, ggplot2, hms,
-htmltools, knitr, lubridate, mockr, nycflights13, pkgbuild,
-pkgload, purrr, rmarkdown, stringi, testthat (>= 3.0.2), tidyr,
-withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tidyr"	"tidyr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.0"	NA	"R (>= 3.1)"	"dplyr (>= 1.0.0), ellipsis (>= 0.1.0), glue, lifecycle,
-magrittr, purrr, rlang, tibble (>= 2.1.1), tidyselect (>=
-1.1.0), utils, vctrs (>= 0.3.7)"	"cpp11 (>= 0.4.0)"	"covr, data.table, jsonlite, knitr, readr, repurrrsive (>=
-1.0.0), rmarkdown, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tidyselect"	"tidyselect"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1.2"	NA	"R (>= 3.2)"	"ellipsis, glue (>= 1.3.0), purrr (>= 0.3.2), rlang (>= 1.0.1),
-vctrs (>= 0.3.0)"	NA	"covr, crayon, dplyr, knitr, magrittr, rmarkdown, testthat (>=
-3.1.1), tibble (>= 2.1.3), withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tinytest"	"tinytest"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.1"	NA	"R (>= 3.0.0)"	"parallel, utils"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"tinytex"	"tinytex"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.39"	NA	NA	"xfun (>= 0.29)"	NA	"testit, rstudioapi"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"TMB"	"TMB"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8.1"	NA	"R (>= 3.0.0)"	"graphics, methods, stats, utils, Matrix (>= 1.0-12)"	"Matrix, RcppEigen"	"numDeriv, parallel"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tmvnsim"	"tmvnsim"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0-2"	NA	NA	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"toOrdinal"	"toOrdinal"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3-0.0"	NA	"R (>= 3.3)"	"crayon, testthat"	NA	"knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"triebeard"	"triebeard"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.0"	NA	NA	"Rcpp"	"Rcpp"	"knitr, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tripack"	"tripack"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3-9.1"	NA	NA	NA	NA	NA	NA	"ACM | file LICENSE"	NA	"yes"	NA	NA	"yes"	"4.2.0"
-"tzdb"	"tzdb"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.3.0"	NA	"R (>= 3.4.0)"	NA	"cpp11 (>= 0.4.2)"	"covr, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"ucminf"	"ucminf"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-4"	NA	NA	NA	NA	"numDeriv"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"units"	"units"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.8-0"	NA	"R (>= 3.0.2)"	"Rcpp"	"Rcpp (>= 0.12.10)"	"NISTunits, measurements, xml2, magrittr, pillar (>= 1.3.0),
+0.3.0), R6, crayon, cli, phangorn, conditionz"	NA	"testthat, vegan, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"terra"	"terra"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7-39"	NA	"R (>= 3.5.0)"	"methods, Rcpp (>= 1.0-10)"	"Rcpp"	"parallel, tinytest, ncdf4, sf (>= 0.9-8), deldir, XML,
+leaflet, htmlwidgets"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"testthat"	"testthat"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.1.10"	NA	"R (>= 3.1)"	"brio, callr (>= 3.5.1), cli (>= 3.4.0), desc, digest, ellipsis
+(>= 0.2.0), evaluate, jsonlite, lifecycle, magrittr, methods,
+pkgload (>= 1.3.0), praise, processx (>= 3.8.2), ps (>= 1.3.4),
+R6 (>= 2.2.0), rlang (>= 1.1.0), utils, waldo (>= 0.5.0), withr
+(>= 2.4.3)"	NA	"covr, curl (>= 0.9.5), diffviewer (>= 0.1.0), knitr,
+rmarkdown, rstudioapi, shiny, usethis, vctrs (>= 0.1.0), xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"textshaping"	"textshaping"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.3.6"	NA	"R (>= 3.2.0)"	"systemfonts (>= 1.0.0)"	"cpp11 (>= 0.2.1), systemfonts (>= 1.0.0)"	"covr, knitr, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"TH.data"	"TH.data"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-2"	NA	"R (>= 3.5.0), survival, MASS"	NA	NA	"trtf, tram, rms, coin, ATR, multcomp, gridExtra, vcd,
+colorspace, lattice, knitr"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"tibble"	"tibble"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.2.1"	NA	"R (>= 3.4.0)"	"fansi (>= 0.4.0), lifecycle (>= 1.0.0), magrittr, methods,
+pillar (>= 1.8.1), pkgconfig, rlang (>= 1.0.2), utils, vctrs
+(>= 0.4.2)"	NA	"bench, bit64, blob, brio, callr, cli, covr, crayon (>=
+1.3.4), DiagrammeR, dplyr, evaluate, formattable, ggplot2,
+here, hms, htmltools, knitr, lubridate, mockr, nycflights13,
+pkgbuild, pkgload, purrr, rmarkdown, stringi, testthat (>=
+3.0.2), tidyr, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"tidyr"	"tidyr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.0"	NA	"R (>= 3.4.0)"	"cli (>= 3.4.1), dplyr (>= 1.0.10), glue, lifecycle (>= 1.0.3),
+magrittr, purrr (>= 1.0.1), rlang (>= 1.0.4), stringr (>=
+1.5.0), tibble (>= 2.1.1), tidyselect (>= 1.2.0), utils, vctrs
+(>= 0.5.2)"	"cpp11 (>= 0.4.0)"	"covr, data.table, knitr, readr, repurrrsive (>= 1.1.0),
+rmarkdown, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"tidyselect"	"tidyselect"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.0"	NA	"R (>= 3.4)"	"cli (>= 3.3.0), glue (>= 1.3.0), lifecycle (>= 1.0.3), rlang
+(>= 1.0.4), vctrs (>= 0.4.1), withr"	NA	"covr, crayon, dplyr, knitr, magrittr, rmarkdown, stringr,
+testthat (>= 3.1.1), tibble (>= 2.1.3)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"timechange"	"timechange"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.2.0"	NA	"R (>= 3.3)"	NA	"cpp11 (>= 0.2.7)"	"testthat (>= 0.7.1.99), knitr"	NA	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"tinytest"	"tinytest"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.4.1"	NA	"R (>= 3.0.0)"	"parallel, utils"	NA	NA	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.2"
+"tinytex"	"tinytex"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.45"	NA	NA	"xfun (>= 0.29)"	NA	"testit, rstudioapi"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"TMB"	"TMB"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.9.5"	NA	"R (>= 3.0.0)"	"graphics, methods, stats, utils, Matrix (>= 1.0-12)"	"Matrix, RcppEigen"	"numDeriv, parallel"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"toOrdinal"	"toOrdinal"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3-0.0"	NA	"R (>= 3.3)"	"crayon, testthat"	NA	"knitr, rmarkdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"triebeard"	"triebeard"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.1"	NA	NA	"Rcpp"	"Rcpp"	"knitr, rmarkdown, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"tzdb"	"tzdb"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.0"	NA	"R (>= 3.5.0)"	NA	"cpp11 (>= 0.4.2)"	"covr, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"ucminf"	"ucminf"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.0"	NA	"R (>= 3.5.0)"	NA	NA	"numDeriv"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"units"	"units"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.8-2"	NA	"R (>= 3.0.2)"	"Rcpp"	"Rcpp (>= 0.12.10)"	"NISTunits, measurements, xml2, magrittr, pillar (>= 1.3.0),
 dplyr (>= 1.0.0), vctrs (>= 0.3.1), ggplot2 (> 3.2.1), testthat
-(>= 3.0.0), vdiffr, knitr, rmarkdown"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"unmarked"	"unmarked"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.5"	NA	"R (>= 2.12.0), methods"	"graphics, lattice, lme4, MASS, Matrix, parallel, pbapply,
-plyr, Rcpp (>= 0.8.0), stats, TMB (>= 1.7.18), utils"	"Rcpp, RcppArmadillo, TMB, RcppEigen"	"knitr, rmarkdown, pkgdown, raster, testthat"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"urltools"	"urltools"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.7.3"	NA	"R (>= 2.10)"	"Rcpp, methods, triebeard"	"Rcpp"	"testthat, knitr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"usethis"	"usethis"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.1.5"	NA	"R (>= 3.4)"	"cli (>= 3.0.1), clipr (>= 0.3.0), crayon, curl (>= 2.7), desc
-(>= 1.4.0), fs (>= 1.3.0), gert (>= 1.4.1), gh (>= 1.2.1), glue
+(>= 3.0.0), vdiffr, knitr, rmarkdown"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"unmarked"	"unmarked"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.2"	NA	"R (>= 2.12.0)"	"graphics, lattice, lme4, MASS, Matrix, methods, parallel,
+pbapply, Rcpp (>= 0.8.0), stats, TMB (>= 1.7.18), utils"	"Rcpp, RcppArmadillo, TMB, RcppEigen"	"knitr, rmarkdown, pkgdown, raster, shiny, terra, testthat"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"urlchecker"	"urlchecker"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.1"	NA	"R (>= 3.3)"	"cli, curl, tools, xml2"	NA	"covr"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"urltools"	"urltools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7.3"	NA	"R (>= 2.10)"	"Rcpp, methods, triebeard"	"Rcpp"	"testthat, knitr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"usethis"	"usethis"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.2.2"	NA	"R (>= 3.6)"	"cli (>= 3.0.1), clipr (>= 0.3.0), crayon, curl (>= 2.7), desc
+(>= 1.4.2), fs (>= 1.3.0), gert (>= 1.4.1), gh (>= 1.2.1), glue
 (>= 1.3.0), jsonlite, lifecycle (>= 1.0.0), purrr, rappdirs,
-rlang (>= 0.4.10), rprojroot (>= 1.2), rstudioapi, stats,
-utils, whisker, withr (>= 2.3.0), yaml"	NA	"covr, knitr, magick, mockr, pkgload, rmarkdown, roxygen2 (>=
-7.1.2), spelling (>= 1.2), styler (>= 1.2.0), testthat (>=
-3.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"utf8"	"utf8"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.2.2"	NA	"R (>= 2.10)"	NA	NA	"cli, covr, knitr, rlang, rmarkdown, testthat (>= 3.0.0),
-withr"	NA	"Apache License (== 2.0) | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"uuid"	"uuid"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-0"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"vctrs"	"vctrs"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.1"	NA	"R (>= 3.3)"	"cli (>= 3.2.0), glue, rlang (>= 1.0.2)"	NA	"bit64, covr, crayon, dplyr (>= 0.8.5), generics, knitr,
+rlang (>= 1.1.0), rprojroot (>= 1.2), rstudioapi, stats, utils,
+whisker, withr (>= 2.3.0), yaml"	NA	"covr, knitr, magick, pkgload, rmarkdown, roxygen2 (>= 7.1.2),
+spelling (>= 1.2), styler (>= 1.2.0), testthat (>= 3.1.8)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"utf8"	"utf8"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.3"	NA	"R (>= 2.10)"	NA	NA	"cli, covr, knitr, rlang, rmarkdown, testthat (>= 3.0.0),
+withr"	NA	"Apache License (== 2.0) | file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"uuid"	"uuid"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-0"	NA	"R (>= 2.9.0)"	NA	NA	NA	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
+"vctrs"	"vctrs"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6.3"	NA	"R (>= 3.5.0)"	"cli (>= 3.4.0), glue, lifecycle (>= 1.0.3), rlang (>= 1.1.0)"	NA	"bit64, covr, crayon, dplyr (>= 0.8.5), generics, knitr,
 pillar (>= 1.4.4), pkgdown (>= 2.0.1), rmarkdown, testthat (>=
-3.0.0), tibble (>= 3.1.3), withr, xml2, waldo (>= 0.2.0),
-zeallot"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"vdiffr"	"vdiffr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.4"	NA	"R (>= 3.2.0)"	"diffobj, glue, grDevices, htmltools, lifecycle, rlang,
-testthat (>= 3.0.3), xml2 (>= 1.0.0)"	"cpp11"	"covr, ggplot2 (>= 3.2.0), roxygen2, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"VGAM"	"VGAM"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1-6"	NA	"R (>= 3.5.0), methods, stats, stats4, splines"	NA	NA	"VGAMextra, MASS, mgcv"	"VGAMdata"	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"VGAMextra"	"VGAMextra"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.0-5"	NA	"R (>= 3.5.0), methods, stats, stats4, VGAM (>= 1.1-0)"	NA	NA	"VGAMdata"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.0"
-"vipor"	"vipor"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.5"	NA	"R (>= 3.0.0)"	"stats, graphics"	NA	"testthat, beeswarm, lattice, ggplot2, beanplot, vioplot,
-ggbeeswarm,"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"viridis"	"viridis"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6.2"	NA	"R (>= 2.10), viridisLite (>= 0.4.0)"	"stats, ggplot2 (>= 1.0.1), gridExtra"	NA	"hexbin (>= 1.27.0), scales, MASS, knitr, dichromat,
-colorspace, raster, rasterVis, httr, mapproj, vdiffr, svglite
-(>= 1.2.0), testthat, covr, rmarkdown, rgdal, maps"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"viridisLite"	"viridisLite"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.0"	NA	"R (>= 2.10)"	NA	NA	"hexbin (>= 1.27.0), ggplot2 (>= 1.0.1), testthat, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"vroom"	"vroom"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.7"	NA	"R (>= 3.1)"	"bit64, crayon, cli, glue, hms, lifecycle, methods, rlang (>=
-0.4.2), stats, tibble (>= 2.0.0), tzdb (>= 0.1.1), vctrs (>=
-0.2.0), tidyselect, withr"	"progress (>= 1.2.1), cpp11 (>= 0.2.0), tzdb (>= 0.1.1)"	"archive, bench (>= 1.1.0), covr, curl, dplyr, forcats, fs,
+3.0.0), tibble (>= 3.1.3), waldo (>= 0.2.0), withr, xml2,
+zeallot"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"vdiffr"	"vdiffr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.5"	NA	"R (>= 3.2.0)"	"diffobj, glue, grDevices, htmltools, lifecycle, rlang,
+testthat (>= 3.0.3), xml2 (>= 1.0.0)"	"cpp11"	"covr, ggplot2 (>= 3.2.0), roxygen2, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"VGAM"	"VGAM"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-8"	NA	"R (>= 4.0.0), methods, stats, stats4, splines"	NA	NA	"VGAMextra, MASS, mgcv"	"VGAMdata"	"GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"VGAMextra"	"VGAMextra"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.0-5"	NA	"R (>= 3.5.0), methods, stats, stats4, VGAM (>= 1.1-0)"	NA	NA	"VGAMdata"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
+"vipor"	"vipor"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.5"	NA	"R (>= 3.0.0)"	"stats, graphics"	NA	"testthat, beeswarm, lattice, ggplot2, beanplot, vioplot,
+ggbeeswarm,"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"viridis"	"viridis"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.6.4"	NA	"R (>= 2.10), viridisLite (>= 0.4.0)"	"ggplot2 (>= 1.0.1), gridExtra"	NA	"hexbin (>= 1.27.0), scales, MASS, knitr, dichromat,
+colorspace, httr, mapproj, vdiffr, svglite (>= 1.2.0),
+testthat, covr, rmarkdown, maps, terra"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"viridisLite"	"viridisLite"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.2"	NA	"R (>= 2.10)"	NA	NA	"hexbin (>= 1.27.0), ggplot2 (>= 1.0.1), testthat, covr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"vroom"	"vroom"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6.3"	NA	"R (>= 3.4)"	"bit64, cli (>= 3.2.0), crayon, glue, hms, lifecycle (>=
+1.0.3), methods, rlang (>= 0.4.2), stats, tibble (>= 2.0.0),
+tidyselect, tzdb (>= 0.1.1), vctrs (>= 0.2.0), withr"	"cpp11 (>= 0.2.0), progress (>= 1.2.1), tzdb (>= 0.1.1)"	"archive, bench (>= 1.1.0), covr, curl, dplyr, forcats, fs,
 ggplot2, knitr, patchwork, prettyunits, purrr, rmarkdown,
 rstudioapi, scales, spelling, testthat (>= 2.1.0), tidyr,
-utils, waldo, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"waldo"	"waldo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.0"	NA	NA	"cli, diffobj (>= 0.3.4), fansi, glue, methods, rematch2, rlang
-(>= 1.0.0), tibble"	NA	"covr, R6, testthat (>= 3.0.0), withr, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"webshot"	"webshot"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.5.3"	NA	"R (>= 3.0)"	"magrittr, jsonlite, callr"	NA	"httpuv, knitr, rmarkdown, shiny"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.0"
-"webutils"	"webutils"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.1"	NA	NA	"curl (>= 2.5), jsonlite"	NA	"httpuv, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"whisker"	"whisker"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4"	NA	NA	NA	NA	"markdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.0"
-"WikidataQueryServiceR"	"WikidataQueryServiceR"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.0"	NA	"R (>= 3.1.2)"	"httr (>= 1.2.1), dplyr (>= 1.0.0), jsonlite (>= 1.2),
+utils, waldo, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"waldo"	"waldo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.1"	NA	NA	"cli, diffobj (>= 0.3.4), fansi, glue, methods, rematch2, rlang
+(>= 1.0.0), tibble"	NA	"covr, R6, testthat (>= 3.0.0), withr, xml2"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"webshot"	"webshot"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5.5"	NA	"R (>= 3.0)"	"magrittr, jsonlite, callr"	NA	"httpuv, knitr, rmarkdown, shiny, testthat (>= 3.0.0)"	NA	"GPL-2"	NA	NA	NA	NA	"no"	"4.2.3"
+"webutils"	"webutils"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1"	NA	NA	"curl (>= 2.5), jsonlite"	NA	"httpuv, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"whisker"	"whisker"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.1"	NA	NA	NA	NA	"markdown"	NA	"GPL-3"	NA	NA	NA	NA	"no"	"4.2.3"
+"WikidataQueryServiceR"	"WikidataQueryServiceR"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R (>= 3.1.2)"	"httr (>= 1.2.1), dplyr (>= 1.0.0), jsonlite (>= 1.2),
 WikipediR (>= 1.5.0), ratelimitr (>= 0.4.1), purrr (>= 0.3.4),
-readr (>= 1.3.1), rex (>= 1.2.0)"	NA	"testthat (>= 2.3.0), lintr (>= 2.0.1)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"WikidataR"	"WikidataR"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3.3"	NA	"R (>= 3.5.0)"	"httr, jsonlite, WikipediR, WikidataQueryServiceR, tibble,
+readr (>= 1.3.1), rex (>= 1.2.0)"	NA	"testthat (>= 2.3.0), lintr (>= 2.0.1)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"WikidataR"	"WikidataR"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.3"	NA	"R (>= 3.5.0)"	"httr, jsonlite, WikipediR, WikidataQueryServiceR, tibble,
 dplyr, stringr, Hmisc, progress, pbapply, stats, readr, crayon,
-utils"	NA	"markdown, testthat, tidyverse, knitr, pageviews"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"WikipediR"	"WikipediR"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.5.0"	NA	NA	"httr, jsonlite"	NA	"testthat, knitr, WikidataR, pageviews"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"wikitaxa"	"wikitaxa"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.0"	NA	"R(>= 3.2.1)"	"WikidataR, data.table, curl, crul (>= 0.3.4), tibble,
-jsonlite, xml2"	NA	"testthat, knitr, rmarkdown, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"withr"	"withr"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.5.0"	NA	"R (>= 3.2.0)"	"graphics, grDevices, stats"	NA	"callr, covr, DBI, knitr, lattice, methods, rlang, rmarkdown
-(>= 2.12), RSQLite, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"wk"	"wk"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.6.0"	NA	NA	NA	NA	"testthat (>= 3.0.0), vctrs (>= 0.3.0), sf, tibble, readr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"worrms"	"worrms"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.4.2"	NA	NA	"crul (>= 0.6.0), tibble (>= 1.2), jsonlite (>= 1.1),
+utils"	NA	"markdown, testthat, tidyverse, knitr, pageviews"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"WikipediR"	"WikipediR"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.5.0"	NA	NA	"httr, jsonlite"	NA	"testthat, knitr, WikidataR, pageviews"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"wikitaxa"	"wikitaxa"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.0"	NA	"R(>= 3.2.1)"	"WikidataR, data.table, curl, crul (>= 0.3.4), tibble,
+jsonlite, xml2"	NA	"testthat, knitr, rmarkdown, vcr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"withr"	"withr"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.5.0"	NA	"R (>= 3.2.0)"	"graphics, grDevices, stats"	NA	"callr, covr, DBI, knitr, lattice, methods, rlang, rmarkdown
+(>= 2.12), RSQLite, testthat (>= 3.0.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"wk"	"wk"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.7.3"	NA	"R (>= 2.10)"	NA	NA	"testthat (>= 3.0.0), vctrs (>= 0.3.0), sf, tibble, readr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"worrms"	"worrms"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.4.3"	NA	NA	"crul (>= 0.6.0), tibble (>= 1.2), jsonlite (>= 1.1),
 data.table"	NA	"roxygen2 (>= 7.1.0), knitr, rmarkdown, testthat, vcr (>=
-0.2.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"xfun"	"xfun"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.31"	NA	NA	"stats, tools"	NA	"testit, parallel, codetools, rstudioapi, tinytex (>= 0.30),
-mime, markdown, knitr, htmltools, remotes, pak, rhub, renv,
-curl, jsonlite, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"XML"	"XML"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"3.99-0.9"	NA	"R (>= 4.0.0), methods, utils"	NA	NA	"bitops, RCurl"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"xml2"	"xml2"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.3.3"	NA	"R (>= 3.1.0)"	"methods"	NA	"covr, curl, httr, knitr, magrittr, mockery, rmarkdown,
-testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"xopen"	"xopen"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.0.0"	NA	"R (>= 3.1)"	"processx"	NA	"ps, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.0"
-"xtable"	"xtable"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8-4"	NA	"R (>= 2.10.0)"	"stats, utils"	NA	"knitr, plm, zoo, survival"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.0"
-"xts"	"xts"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"0.12.1"	NA	"zoo (>= 1.7-12)"	"methods"	"zoo"	"timeSeries, timeDate, tseries, chron, fts, tis, RUnit"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"yaml"	"yaml"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.3.5"	NA	NA	NA	NA	"RUnit"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"zip"	"zip"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"2.2.0"	NA	NA	NA	NA	"covr, processx, R6, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"zoo"	"zoo"	"G:/workspace/precip_rionegro/renv/library/R-4.2/x86_64-w64-mingw32"	"1.8-10"	NA	"R (>= 3.1.0), stats"	"utils, graphics, grDevices, lattice (>= 0.20-27)"	NA	"AER, coda, chron, fts, ggplot2 (>= 3.0.0), mondate, scales,
-stinepack, strucchange, timeDate, timeSeries, tis, tseries, xts"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"base"	"base"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	"methods"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	NA	"4.2.0"
-"boot"	"boot"	"C:/Program Files/R/R-4.2.0/library"	"1.3-28"	"recommended"	"R (>= 3.0.0), graphics, stats"	NA	NA	"MASS, survival"	NA	"Unlimited"	NA	NA	NA	NA	"no"	"4.2.0"
-"class"	"class"	"C:/Program Files/R/R-4.2.0/library"	"7.3-20"	"recommended"	"R (>= 3.0.0), stats, utils"	"MASS"	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"cluster"	"cluster"	"C:/Program Files/R/R-4.2.0/library"	"2.1.3"	"recommended"	"R (>= 3.5.0)"	"graphics, grDevices, stats, utils"	NA	"MASS, Matrix"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"codetools"	"codetools"	"C:/Program Files/R/R-4.2.0/library"	"0.2-18"	"recommended"	"R (>= 2.1)"	NA	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.0"
-"compiler"	"compiler"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	NA	"4.2.0"
-"datasets"	"datasets"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	NA	"4.2.0"
-"foreign"	"foreign"	"C:/Program Files/R/R-4.2.0/library"	"0.8-82"	"recommended"	"R (>= 4.0.0)"	"methods, utils, stats"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"graphics"	"graphics"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"grDevices"	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"grDevices"	"grDevices"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	"KernSmooth"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"grid"	"grid"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"grDevices, utils"	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"KernSmooth"	"KernSmooth"	"C:/Program Files/R/R-4.2.0/library"	"2.23-20"	"recommended"	"R (>= 2.5.0), stats"	NA	NA	"MASS, carData"	NA	"Unlimited"	NA	NA	NA	NA	"yes"	"4.2.0"
-"lattice"	"lattice"	"C:/Program Files/R/R-4.2.0/library"	"0.20-45"	"recommended"	"R (>= 3.0.0)"	"grid, grDevices, graphics, stats, utils"	NA	"KernSmooth, MASS, latticeExtra"	"chron"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"MASS"	"MASS"	"C:/Program Files/R/R-4.2.0/library"	"7.3-56"	"recommended"	"R (>= 3.3.0), grDevices, graphics, stats, utils"	"methods"	NA	"lattice, nlme, nnet, survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"Matrix"	"Matrix"	"C:/Program Files/R/R-4.2.0/library"	"1.4-1"	"recommended"	"R (>= 3.5.0)"	"methods, graphics, grid, stats, utils, lattice"	NA	"expm, MASS"	"MatrixModels, graph, SparseM, sfsmisc, igraph, maptools, sp,
-spdep"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.0"
-"methods"	"methods"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"utils, stats"	NA	"codetools"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"mgcv"	"mgcv"	"C:/Program Files/R/R-4.2.0/library"	"1.8-40"	"recommended"	"R (>= 3.6.0), nlme (>= 3.1-64)"	"methods, stats, graphics, Matrix, splines, utils"	NA	"parallel, survival, MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"nlme"	"nlme"	"C:/Program Files/R/R-4.2.0/library"	"3.1-157"	"recommended"	"R (>= 3.5.0)"	"graphics, stats, utils, lattice"	NA	"Hmisc, MASS, SASmixed"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"nnet"	"nnet"	"C:/Program Files/R/R-4.2.0/library"	"7.3-17"	"recommended"	"R (>= 3.0.0), stats, utils"	NA	NA	"MASS"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"parallel"	"parallel"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"tools, compiler"	NA	"methods"	"snow, nws, Rmpi"	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"rpart"	"rpart"	"C:/Program Files/R/R-4.2.0/library"	"4.1.16"	"recommended"	"R (>= 2.15.0), graphics, stats, grDevices"	NA	NA	"survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"spatial"	"spatial"	"C:/Program Files/R/R-4.2.0/library"	"7.3-15"	"recommended"	"R (>= 3.0.0), graphics, stats, utils"	NA	NA	"MASS"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.0"
-"splines"	"splines"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"graphics, stats"	NA	"Matrix, methods"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"stats"	"stats"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"utils, grDevices, graphics"	NA	"MASS, Matrix, SuppDists, methods, stats4"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"stats4"	"stats4"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"graphics, methods, stats"	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	NA	"4.2.0"
-"survival"	"survival"	"C:/Program Files/R/R-4.2.0/library"	"3.3-1"	"recommended"	"R (>= 3.5.0)"	"graphics, Matrix, methods, splines, stats, utils"	NA	NA	NA	"LGPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tcltk"	"tcltk"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	"utils"	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"tools"	"tools"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	"codetools, methods, xml2, curl, commonmark, knitr, xfun,
-mathjaxr"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
-"translations"	"translations"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	NA	NA	NA	NA	NA	NA	"Part of R 4.2.0"	NA	NA	NA	NA	NA	"4.2.0"
-"utils"	"utils"	"C:/Program Files/R/R-4.2.0/library"	"4.2.0"	"base"	NA	NA	NA	"methods, xml2, commonmark, knitr"	NA	"Part of R 4.2.0"	NA	NA	NA	NA	"yes"	"4.2.0"
+0.2.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"xfun"	"xfun"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.39"	NA	NA	"stats, tools"	NA	"testit, parallel, codetools, rstudioapi, tinytex (>= 0.30),
+mime, markdown (>= 1.5), knitr (>= 1.42), htmltools, remotes,
+pak, rhub, renv, curl, jsonlite, magick, yaml, rmarkdown"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"XML"	"XML"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.99-0.14"	NA	"R (>= 4.0.0), methods, utils"	NA	NA	"bitops, RCurl"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"xml2"	"xml2"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.3.5"	NA	"R (>= 3.1.0)"	"methods"	NA	"covr, curl, httr, knitr, magrittr, mockery, rmarkdown,
+testthat (>= 2.1.0)"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"xopen"	"xopen"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R (>= 3.1)"	"processx"	NA	"ps, testthat"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
+"xtable"	"xtable"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8-4"	NA	"R (>= 2.10.0)"	"stats, utils"	NA	"knitr, plm, zoo, survival"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
+"xts"	"xts"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.13.1"	NA	"R (>= 3.6.0), zoo (>= 1.7-12)"	"methods"	"zoo"	"timeSeries, timeDate, tseries, chron, tinytest"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
+"yaml"	"yaml"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.7"	NA	NA	NA	NA	"RUnit"	NA	"BSD_3_clause + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"zip"	"zip"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.0"	NA	NA	NA	NA	"covr, processx, R6, testthat, withr"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"zoo"	"zoo"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.8-12"	NA	"R (>= 3.1.0), stats"	"utils, graphics, grDevices, lattice (>= 0.20-27)"	NA	"AER, coda, chron, ggplot2 (>= 3.0.0), mondate, scales,
+stinepack, strucchange, timeDate, timeSeries, tis, tseries, xts"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.3"
+"base"	"base"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	"methods"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	NA	"4.2.2"
+"boot"	"boot"	"C:/Program Files/R/R-4.2.2/library"	"1.3-28"	"recommended"	"R (>= 3.0.0), graphics, stats"	NA	NA	"MASS, survival"	NA	"Unlimited"	NA	NA	NA	NA	"no"	"4.2.2"
+"class"	"class"	"C:/Program Files/R/R-4.2.2/library"	"7.3-20"	"recommended"	"R (>= 3.0.0), stats, utils"	"MASS"	NA	NA	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"cluster"	"cluster"	"C:/Program Files/R/R-4.2.2/library"	"2.1.4"	"recommended"	"R (>= 3.5.0)"	"graphics, grDevices, stats, utils"	NA	"MASS, Matrix"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"codetools"	"codetools"	"C:/Program Files/R/R-4.2.2/library"	"0.2-18"	"recommended"	"R (>= 2.1)"	NA	NA	NA	NA	"GPL"	NA	NA	NA	NA	"no"	"4.2.2"
+"compiler"	"compiler"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	NA	"4.2.2"
+"datasets"	"datasets"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	NA	"4.2.2"
+"foreign"	"foreign"	"C:/Program Files/R/R-4.2.2/library"	"0.8-83"	"recommended"	"R (>= 4.0.0)"	"methods, utils, stats"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"graphics"	"graphics"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"grDevices"	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"grDevices"	"grDevices"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	"KernSmooth"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"grid"	"grid"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"grDevices, utils"	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"KernSmooth"	"KernSmooth"	"C:/Program Files/R/R-4.2.2/library"	"2.23-20"	"recommended"	"R (>= 2.5.0), stats"	NA	NA	"MASS, carData"	NA	"Unlimited"	NA	NA	NA	NA	"yes"	"4.2.2"
+"lattice"	"lattice"	"C:/Program Files/R/R-4.2.2/library"	"0.20-45"	"recommended"	"R (>= 3.0.0)"	"grid, grDevices, graphics, stats, utils"	NA	"KernSmooth, MASS, latticeExtra"	"chron"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"MASS"	"MASS"	"C:/Program Files/R/R-4.2.2/library"	"7.3-58.1"	"recommended"	"R (>= 3.3.0), grDevices, graphics, stats, utils"	"methods"	NA	"lattice, nlme, nnet, survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"Matrix"	"Matrix"	"C:/Program Files/R/R-4.2.2/library"	"1.5-1"	"recommended"	"R (>= 3.5.0)"	"methods, graphics, grid, stats, utils, lattice"	NA	"expm, MASS"	"MatrixModels, graph, SparseM, sfsmisc, igraph, maptools, sp,
+spdep"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.2"
+"methods"	"methods"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"utils, stats"	NA	"codetools"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"mgcv"	"mgcv"	"C:/Program Files/R/R-4.2.2/library"	"1.8-41"	"recommended"	"R (>= 3.6.0), nlme (>= 3.1-64)"	"methods, stats, graphics, Matrix, splines, utils"	NA	"parallel, survival, MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"nlme"	"nlme"	"C:/Program Files/R/R-4.2.2/library"	"3.1-160"	"recommended"	"R (>= 3.5.0)"	"graphics, stats, utils, lattice"	NA	"Hmisc, MASS, SASmixed"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"nnet"	"nnet"	"C:/Program Files/R/R-4.2.2/library"	"7.3-18"	"recommended"	"R (>= 3.0.0), stats, utils"	NA	NA	"MASS"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"parallel"	"parallel"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"tools, compiler"	NA	"methods"	"snow, nws, Rmpi"	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"rpart"	"rpart"	"C:/Program Files/R/R-4.2.2/library"	"4.1.19"	"recommended"	"R (>= 2.15.0), graphics, stats, grDevices"	NA	NA	"survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"spatial"	"spatial"	"C:/Program Files/R/R-4.2.2/library"	"7.3-15"	"recommended"	"R (>= 3.0.0), graphics, stats, utils"	NA	NA	"MASS"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
+"splines"	"splines"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"graphics, stats"	NA	"Matrix, methods"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"stats"	"stats"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"utils, grDevices, graphics"	NA	"MASS, Matrix, SuppDists, methods, stats4"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"stats4"	"stats4"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"graphics, methods, stats"	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	NA	"4.2.2"
+"survival"	"survival"	"C:/Program Files/R/R-4.2.2/library"	"3.4-0"	"recommended"	"R (>= 3.5.0)"	"graphics, Matrix, methods, splines, stats, utils"	NA	NA	NA	"LGPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
+"tcltk"	"tcltk"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"utils"	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"tools"	"tools"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	"codetools, methods, xml2, curl, commonmark, knitr, xfun,
+mathjaxr"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
+"translations"	"translations"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	NA	NA	NA	NA	NA	NA	"Part of R 4.2.2"	NA	NA	NA	NA	NA	"4.2.2"
+"utils"	"utils"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	NA	NA	"methods, xml2, commonmark, knitr"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"

--- a/instalarPaquetes/min_pkg_versions.tsv
+++ b/instalarPaquetes/min_pkg_versions.tsv
@@ -776,8 +776,6 @@ stinepack, strucchange, timeDate, timeSeries, tis, tseries, xts"	NA	"GPL-2 | GPL
 "KernSmooth"	"KernSmooth"	"C:/Program Files/R/R-4.2.2/library"	"2.23-20"	"recommended"	"R (>= 2.5.0), stats"	NA	NA	"MASS, carData"	NA	"Unlimited"	NA	NA	NA	NA	"yes"	"4.2.2"
 "lattice"	"lattice"	"C:/Program Files/R/R-4.2.2/library"	"0.20-45"	"recommended"	"R (>= 3.0.0)"	"grid, grDevices, graphics, stats, utils"	NA	"KernSmooth, MASS, latticeExtra"	"chron"	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
 "MASS"	"MASS"	"C:/Program Files/R/R-4.2.2/library"	"7.3-58.1"	"recommended"	"R (>= 3.3.0), grDevices, graphics, stats, utils"	"methods"	NA	"lattice, nlme, nnet, survival"	NA	"GPL-2 | GPL-3"	NA	NA	NA	NA	"yes"	"4.2.2"
-"Matrix"	"Matrix"	"C:/Program Files/R/R-4.2.2/library"	"1.5-1"	"recommended"	"R (>= 3.5.0)"	"methods, graphics, grid, stats, utils, lattice"	NA	"expm, MASS"	"MatrixModels, graph, SparseM, sfsmisc, igraph, maptools, sp,
-spdep"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.2"
 "methods"	"methods"	"C:/Program Files/R/R-4.2.2/library"	"4.2.2"	"base"	NA	"utils, stats"	NA	"codetools"	NA	"Part of R 4.2.2"	NA	NA	NA	NA	"yes"	"4.2.2"
 "mgcv"	"mgcv"	"C:/Program Files/R/R-4.2.2/library"	"1.8-41"	"recommended"	"R (>= 3.6.0), nlme (>= 3.1-64)"	"methods, stats, graphics, Matrix, splines, utils"	NA	"parallel, survival, MASS"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"
 "nlme"	"nlme"	"C:/Program Files/R/R-4.2.2/library"	"3.1-160"	"recommended"	"R (>= 3.5.0)"	"graphics, stats, utils, lattice"	NA	"Hmisc, MASS, SASmixed"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.2"

--- a/instalarPaquetes/min_pkg_versions.tsv
+++ b/instalarPaquetes/min_pkg_versions.tsv
@@ -333,7 +333,7 @@ rstantools, spdep, testthat (>= 2.1.0)"	NA	"GPL (>= 3)"	NA	NA	NA	NA	"no"	"4.2.3"
 "mapdata"	"mapdata"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"2.3.1"	NA	"R (>= 2.14.0), maps (>= 2.0-7)"	NA	NA	NA	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
 "mapproj"	"mapproj"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.2.11"	NA	"R (>= 3.0.0), maps (>= 2.3-0)"	"stats, graphics"	NA	NA	NA	"Lucent Public License"	NA	NA	NA	NA	"yes"	"4.2.3"
 "maps"	"maps"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"3.4.1"	NA	"R (>= 3.5.0)"	"graphics, utils"	NA	"mapproj (>= 1.2-0), mapdata (>= 2.3.0), sp, rnaturalearth"	NA	"GPL-2"	NA	NA	NA	NA	"yes"	"4.2.3"
-"maptools"	"maptools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-8"	NA	"R (>= 2.10), sp (>= 1.0-11)"	"foreign (>= 0.8), methods, grid, lattice, stats, utils,
+"maptools"	"maptools"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.1-4"	NA	"R (>= 2.10), sp (>= 1.0-11)"	"foreign (>= 0.8), methods, grid, lattice, stats, utils,
 grDevices"	NA	"rgeos (>= 0.1-8), spatstat.geom (>= 1.65-0), PBSmapping,
 maps, RColorBrewer, raster, polyclip, plotrix, spatstat.linnet
 (>= 1.65-3), spatstat.utils (>= 1.19.0), spatstat (>= 2.0-0)"	NA	"GPL (>= 2)"	NA	NA	NA	NA	"yes"	"4.2.3"
@@ -343,7 +343,7 @@ servr, sf, sp, webshot"	NA	"covr, knitr, later, leaflet.extras2, leafsync, lwgeo
 mapdeck, plainview, poorman, rgdal, rmarkdown, rstudioapi, s2,
 stars, tinytest"	NA	"GPL (>= 3) | file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
 "markdown"	"markdown"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.7"	NA	"R (>= 2.11.1)"	"utils, commonmark (>= 1.9.0), xfun (>= 0.38)"	NA	"knitr, rmarkdown (>= 2.18), yaml, RCurl"	NA	"MIT + file LICENSE"	NA	NA	NA	NA	"no"	"4.2.3"
-"Matrix"	"Matrix"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6-0"	"recommended"	"R (>= 3.5.0), methods"	"grDevices, graphics, grid, lattice, stats, utils"	NA	"MASS, datasets, sfsmisc"	"SparseM, graph"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.3"
+"Matrix"	"Matrix"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.6-3"	"recommended"	"R (>= 3.5.0), methods"	"grDevices, graphics, grid, lattice, stats, utils"	NA	"MASS, datasets, sfsmisc"	"SparseM, graph"	"GPL (>= 2) | file LICENCE"	NA	NA	NA	NA	"yes"	"4.2.3"
 "MatrixModels"	"MatrixModels"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"0.5-2"	NA	"R (>= 3.6.0)"	"stats, methods, Matrix (>= 1.6-0)"	NA	NA	NA	"GPL (>= 2)"	NA	NA	NA	NA	"no"	"4.2.3"
 "matrixStats"	"matrixStats"	"C:/Users/ludec/AppData/Local/R/win-library/4.2"	"1.0.0"	NA	"R (>= 2.12.0)"	NA	NA	"base64enc, ggplot2, knitr, markdown, microbenchmark,
 R.devices, R.rsp"	NA	"Artistic-2.0"	NA	NA	NA	NA	"yes"	"4.2.3"

--- a/interpolar/interpolarEx.r
+++ b/interpolar/interpolarEx.r
@@ -492,7 +492,9 @@ cargarSHPYObtenerMascaraParaGrilla <- function(
     objCache <- list(pathSHP, proj4strSHP, grilla, spSinMascara, overrideP4str, encoding)
     pathCache <- getPathCache(
       objCache, dirEjecucion=paste0(dirname(pathSHP), '/'), 
-      prefijoNombreArchivoCache=paste0(nombreArchSinPathNiExtension(pathSHP), '_'))
+      prefijoNombreArchivoCache=paste0(nombreArchSinPathNiExtension(pathSHP), '_'),
+      subPathFuncionConBarra='cargarSHPYObtenerMascaraParaGrilla/'
+    )
     if (!file.exists(pathCache)) {
       shp <- cargarSHP(pathSHP, proj4strSHP, overrideP4str=overrideP4str, encoding=encoding)
       if (!identicalCRS(grilla, shp)) { shp <- spTransform(shp, grilla@proj4string) }
@@ -1886,7 +1888,11 @@ cachearRegresoresEstaticos <- function(
   
   # Regresores estáticos sobre coordenadas a interpolar
   source(paste0(script.dir.interpolarEx, '../cacheFunciones/cacheFunciones.r'))
-  pathCacheDatosCoordsAInterpolar <- getPathCache(objParametros=list(coordsAInterpolar, version=2))
+  pathCacheDatosCoordsAInterpolar <- getPathCache(
+    objParametros=list(coordsAInterpolar, version=2), 
+    subPathFuncionConBarra='incorporarRegresoresEstaticos/',
+    prefijoNombreArchivoCache='datosCoordsAInterpolar_'
+  )
   if (recalculateIfAlreadyExists | 
       !file.exists(pathCacheDatosCoordsAInterpolar) | 
       file.info(pathCacheDatosCoordsAInterpolar)$size <= 0
@@ -1923,7 +1929,11 @@ cachearRegresoresEstaticos <- function(
   
   # Regresores estáticos sobre coordenadas de observaciones
   dfDatosCoordsObservaciones <- list()
-  pathCacheDatosCoordsObservaciones <- getPathCache(objParametros=list(coordsObservaciones, version=2))
+  pathCacheDatosCoordsObservaciones <- getPathCache(
+    objParametros=list(coordsObservaciones, version=2), 
+    subPathFuncionConBarra='incorporarRegresoresEstaticos/',
+    prefijoNombreArchivoCache='datosCoordsObservaciones_'
+  )
   if (
     recalculateIfAlreadyExists |
     !file.exists(pathCacheDatosCoordsObservaciones) | 
@@ -1982,8 +1992,16 @@ incorporarRegresoresEstaticos <- function(
   
   geomCoordsInterp <- geometry(coordsAInterpolar)
   geomCoordsObs <- geometry(coordsObservaciones)
-  pathCacheDatosCoordsAInterpolar <- getPathCache(objParametros=list(geomCoordsInterp, version=2))
-  pathCacheDatosCoordsObservaciones <- getPathCache(objParametros=list(geomCoordsObs, version=2))
+  pathCacheDatosCoordsAInterpolar <- getPathCache(
+    objParametros=list(geomCoordsInterp, version=2), 
+    subPathFuncionConBarra='incorporarRegresoresEstaticos/',
+    prefijoNombreArchivoCache='datosCoordsAInterpolar_'
+  )
+  pathCacheDatosCoordsObservaciones <- getPathCache(
+    objParametros=list(geomCoordsObs, version=2), 
+    subPathFuncionConBarra='incorporarRegresoresEstaticos/',
+    prefijoNombreArchivoCache='datosCoordsObservaciones_'
+  )
   if (
     !file.exists(pathCacheDatosCoordsAInterpolar) | 
     !file.exists(pathCacheDatosCoordsObservaciones) | 

--- a/interpolar/mapearEx.r
+++ b/interpolar/mapearEx.r
@@ -38,7 +38,8 @@ source(paste0(script.dir.mapearEx, '../pathUtils/pathUtils.r'))
 source(paste0(script.dir.mapearEx, '../instalarPaquetes/instant_pkgs.r'))
 instant_pkgs(
   c("sp", "RColorBrewer", "colorspace", "ggplot2", "rgeos", "maptools", "directlabels", "ggrepel", 
-    "ragg", "mapproj"))
+    "ragg", "mapproj")
+)
 
 paletasInvertidas <- c('Spectral', 'RdBu', 'RdYlBu', 'RdYlGn')
 

--- a/qc/qcTests.r
+++ b/qc/qcTests.r
@@ -1439,12 +1439,10 @@ testEspacialPrecipitacion <- function(
     # but it works ok for both the cases where there is a single temporal observation (in which 
     # it's usually a lot faster to run in 1 core), and also where there's a long period of time
     # (where the overhead is paid for by the speedup)
-    ramLimitedNCores <- getAvailableCores(maxCoresPerGB = 1)
-    if (ncol(valoresObservaciones) * nrow(valoresObservaciones) > ramLimitedNCores * 16) {
-      nCoresAUsar <- min(ramLimitedNCores, ncol(valoresObservaciones))
-    } else {
-      nCoresAUsar <- 1
-    }
+    nCoresAUsar <- getAvailableCores(
+      maxCoresPerGB=1, 
+      unitsOfWork=ncol(valoresObservaciones) * nrow(valoresObservaciones)
+    )
   }
   if (nCoresAUsar > 1) {
     cl <- makeCluster(getOption('cl.cores', nCoresAUsar))
@@ -1528,7 +1526,10 @@ testMaxToMeanRatios <- function(valoresObservaciones, minMaxVal=20, maxRatio=30,
   }
   
   if (nCoresAUsar <= 0) { 
-    nCoresAUsar <- min(getAvailableCores(maxCoresPerGB = 1), ncol(valoresObservaciones))
+    nCoresAUsar <- getAvailableCores(
+      maxCoresPerGB=1, 
+      unitsOfWork=ncol(valoresObservaciones) * nrow(valoresObservaciones)
+    )
   }
   if (nCoresAUsar > 1) {
     cl <- makeCluster(getOption('cl.cores', nCoresAUsar))

--- a/sysutils/sysutils.r
+++ b/sysutils/sysutils.r
@@ -42,6 +42,19 @@ getTotalRAM_GB <- function() {
   return(memtot_gb)
 }
 
-getAvailableCores <- function(logicalCores=TRUE, maxCoresPerGB=Inf) {
-  return(min(detectCores(T, logical=logicalCores), trunc(getTotalRAM_GB() * maxCoresPerGB)))
+getAvailableCores <- function(
+    logicalCores=TRUE, 
+    maxCoresPerGB=Inf, 
+    unitsOfWork=NA_integer_, 
+    minUnitsOfWorkPerCore=16L
+) {
+  ramLimitedNCores <- min(
+    parallel::detectCores(T, logical=logicalCores),
+    trunc(getTotalRAM_GB() * maxCoresPerGB)
+  )
+  if (!is.na(unitsOfWork) && (unitsOfWork < minUnitsOfWorkPerCore * ramLimitedNCores)) {
+    return(1L)
+  } else {
+    return(ramLimitedNCores)
+  }
 }


### PR DESCRIPTION
- Avoid a race condition when caching certain functions by using a filelock to ensure a single writer (and multiple readers) holds the cache file
- Organize cache files so that their names are more reflective of their contents
- Implement `getTotalRAM_GB` for Windows Systems
- Update min_pkg_versions.tsv 
- Fix an issue with the single core version of testEspacialPrecipitacion
-  Limit number of cores used in testEspacialPrecipitacion and testMaxToMeanRatios if there's few rows * columns in valoresObservaciones
- Add option to record packages installed by instant_pkgs to a file
- Drop usage of maptools in mapearEx.r
- Fix an issue with recording installed packages in instant_pkgs